### PR TITLE
Fix/ats 825/kirkstone

### DIFF
--- a/conf/distro/sota.conf.inc
+++ b/conf/distro/sota.conf.inc
@@ -7,15 +7,9 @@
 DISTRO_FEATURES:append = " sota usrmerge"
 DISTRO_FEATURES_NATIVE:append = " sota"
 INHERIT += " sota"
-# Prelinking increases the size of downloads and causes build errors
-USER_CLASSES:remove = "image-prelink"
-
-# Enable reproducible builds. Use 0 as mtime, the same as OSTree is using.
-INHERIT:remove = "reproducible_build"
-INHERIT += "reproducible_build_simple"
 
 export SOURCE_DATE_EPOCH = "0"
 REPRODUCIBLE_TIMESTAMP_ROOTFS = "0"
 
-HOSTTOOLS += "git sync sha256sum"
+HOSTTOOLS += "sync"
 HOSTTOOLS_NONFATAL += "java repo"

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -12,7 +12,7 @@ BBFILE_PRIORITY_sota = "7"
 LAYERDEPENDS_sota = "openembedded-layer"
 LAYERDEPENDS_sota += "meta-python"
 LAYERDEPENDS_sota += "filesystems-layer"
-LAYERSERIES_COMPAT_sota = "dunfell gatesgarth hardknott honister"
+LAYERSERIES_COMPAT_sota = "honister"
 
 SIGGEN_EXCLUDE_SAFE_RECIPE_DEPS += " \
   aktualizr-device-prov->aktualizr \


### PR DESCRIPTION
Fixes https://github.com/advancedtelematic/meta-updater/issues/825.

FYI @shr-project I'm not really supporting the old advancedtelematic repos anymore; this is the central repo now.

We have separate gatesgarth and hardknott repos here, although they are identical to the current master. Do we need a separate honister branch now as well, or is that still compatible with the changes here? I don't have a great way to test master these days, so I'm somewhat reliant on you or others to confirm if this is working.