### PR TITLE
aktualizr: package pkgconfig file

### DIFF
--- a/recipes-sota/aktualizr/aktualizr_git.bb
+++ b/recipes-sota/aktualizr/aktualizr_git.bb
@@ -169,6 +169,7 @@ FILES:${PN}-sotatools-lib = " \
 
 FILES:${PN}-dev = " \
                 ${includedir}/lib${PN} \
+                ${libdir}/pkgconfig \
                 "
 
 BBCLASSEXTEND = "native"


### PR DESCRIPTION
* fixes:
ERROR: aktualizr-1.0+gitAUTOINC+5575d673bc-7 do_package: QA Issue: aktualizr: Files/directories were installed but not shipped in any package:
  /usr/lib/pkgconfig
  /usr/lib/pkgconfig/aktualizr.pc
Please set FILES such that these items are packaged. Alternatively if they are unneeded, avoid installing them or delete them within do_install.
aktualizr: 2 installed and not shipped files. [installed-vs-shipped]

Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>