### PR TITLE
aktualizr: use https protocol to fetch it

### DIFF
--- a/recipes-sota/aktualizr/aktualizr_git.bb
+++ b/recipes-sota/aktualizr/aktualizr_git.bb
@@ -19,7 +19,7 @@ PR = "7"
 GARAGE_SIGN_PV = "0.7.4-2-gc58e400"
 
 SRC_URI = " \
-  gitsm://github.com/uptane/aktualizr;branch=${BRANCH};name=aktualizr \
+  gitsm://github.com/uptane/aktualizr;branch=${BRANCH};name=aktualizr;protocol=https \
   file://run-ptest \
   file://aktualizr.service \
   file://aktualizr-secondary.service \


### PR DESCRIPTION
* github decided that nobody should use git://
  https://github.blog/2021-09-01-improving-git-protocol-security-github/#no-more-unauthenticated-git

  and starting today all the builds were failing to fetch the metadata
  layers from github like:

  2021-11-01T18:53:26 INFO _main_ Updating [meta-ros]
  fatal: remote error:
    The unauthenticated git protocol on port 9418 is no longer supported.
  Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.

  this was just a "test" as they said:
  "November 2, 2021: We'll also run several short brownouts on this date."
  and it will be completely disabled on January 11 2022.

Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>