### PR TITLE
[kirkstone] sota.bbclass: update for renamed ssl PACKAGECONFIG in curl recipe

### DIFF
--- a/classes/sota.bbclass
+++ b/classes/sota.bbclass
@@ -13,8 +13,10 @@ IMAGE_FSTYPES += "${@bb.utils.contains('DISTRO_FEATURES', 'sota', 'ostreepush ga
 IMAGE_FSTYPES += "${@bb.utils.contains('BUILD_OSTREE_TARBALL', '1', 'ostree.tar.bz2', ' ', d)}"
 IMAGE_FSTYPES += "${@bb.utils.contains('BUILD_OTA_TARBALL', '1', 'ota.tar.xz', ' ', d)}"
 
-PACKAGECONFIG:append:pn-curl = " ssl"
-PACKAGECONFIG:remove:pn-curl = "gnutls"
+SOTA_CURL_PACKAGECONFIG_APPEND ?= "openssl"
+SOTA_CURL_PACKAGECONFIG_REMOVE ?= "gnutls"
+PACKAGECONFIG:append:pn-curl = " ${SOTA_CURL_PACKAGECONFIG_APPEND}"
+PACKAGECONFIG:remove:pn-curl = "${SOTA_CURL_PACKAGECONFIG_REMOVE}"
 
 WKS_FILE:sota ?= "sdimage-sota.wks"
 


### PR DESCRIPTION
* it's not clear why sota replaces gnutls with openssl support for curl
  and it should be rather DISTRO policy doing this (openssl is enabled
  by default and if some DISTRO chooses gnutls for whatever reason,
  enabling sota probably shouldn't just overrule that decision,
  especially as the remove operator from
  PACKAGECONFIG:remove:pn-curl
  is impossible to undo)

* add intermediate variables to make it possible to "undo" this by
  setting both to empty in your distro config and replace 'ssl' with
  'openssl'

* it was introduced in:
    https://github.com/uptane/meta-updater/commit/9d9b6a8eb297e7e90a680730bfc5068deb19a138

* 'ssl' PACKAGECONFIG was removed in:
    https://github.com/openembedded/openembedded-core/commit/eef6c45fc6ec0a496791123e8ba2f400a5d9d468

Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>