### PR TITLE
ostree: patch to setup a curl request timeout

### DIFF
--- a/recipes-extended/ostree/ostree/0001-ostree-pull-set-request-timeout.patch
+++ b/recipes-extended/ostree/ostree/0001-ostree-pull-set-request-timeout.patch
@@ -1,0 +1,35 @@
+From 8f076eb377f3345e1df3302930456c7575d0dc89 Mon Sep 17 00:00:00 2001
+From: Mike Sul <mike.sul@foundries.io>
+Date: Sat, 3 Jul 2021 20:37:08 -0300
+Subject: [PATCH] ostree-fetcher-curl: set a timeout for an overall request
+ processing
+
+Signed-off-by: Mike Sul <mike.sul@foundries.io>
+Signed-off-by: Ricardo Salveti <ricardo@foundries.io>
+---
+ src/libostree/ostree-fetcher-curl.c | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/src/libostree/ostree-fetcher-curl.c b/src/libostree/ostree-fetcher-curl.c
+index d6534b46..1253da29 100644
+--- a/src/libostree/ostree-fetcher-curl.c
++++ b/src/libostree/ostree-fetcher-curl.c
+@@ -891,6 +891,15 @@ initiate_next_curl_request (FetcherRequest *req,
+   curl_easy_setopt (req->easy, CURLOPT_HEADERDATA, task);
+   curl_easy_setopt (req->easy, CURLOPT_PROGRESSDATA, task);
+ 
++  /* set a request timeout, make sure it's not 0, otherwise an overall ostree pull session might hang */
++  long curl_timeout = 0L;
++  const char* curl_timeout_str = g_getenv ("OSTREE_CURL_TIMEOUT");
++  if (curl_timeout_str != NULL)
++    curl_timeout = atoi(curl_timeout_str);
++  if (curl_timeout == 0)
++    curl_timeout = 780L;
++  curl_easy_setopt (req->easy, CURLOPT_TIMEOUT, curl_timeout);
++
+   CURLMcode multi_rc = curl_multi_add_handle (self->multi, req->easy);
+   g_assert (multi_rc == CURLM_OK);
+ }
+-- 
+2.32.0
+

--- a/recipes-extended/ostree/ostree_%.bbappend
+++ b/recipes-extended/ostree/ostree_%.bbappend
@@ -1,4 +1,10 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+SRC_URI += " \
+            file://0001-ostree-pull-set-request-timeout.patch \
+            "
+
 PACKAGECONFIG:append = " curl libarchive static builtin-grub2-mkconfig"
 PACKAGECONFIG:class-native:append = " curl"
-PACKAGECONFIG:remove = "soup"
-PACKAGECONFIG:class-native:remove = "soup"
+# gpgme is not required by us, and it brings GPLv3 dependencies
+PACKAGECONFIG:remove = "soup gpgme"


### PR DESCRIPTION
Set a timeout for an overall request processing in order to avoid an
ostree pull/fetch API call or CLI command hang.  The timeout value can
be specified via an env variable OSTREE_CURL_TIMEOUT, if not defined, or
equal 0 or it cannot be converted to a long type then the default value
is set.

Based on 2b742b96341a245b2a1c66bb93a837345e533c63 in meta-lmp; see
https://github.com/foundriesio/meta-lmp/pull/382 and
https://github.com/foundriesio/meta-lmp/pull/391.

See also https://github.com/ostreedev/ostree/issues/2383.