### PR TITLE
classes/sota: no need to add wic when sota is enabled

### DIFF
--- a/classes/sota.bbclass
+++ b/classes/sota.bbclass
@@ -9,7 +9,7 @@ IMAGE_INSTALL:append:sota = " aktualizr aktualizr-info ${SOTA_CLIENT_PROV} \
                               ostree os-release ostree-kernel ostree-initramfs \
                               ${@'ostree-devicetrees' if oe.types.boolean('${OSTREE_DEPLOY_DEVICETREE}') else ''}"
 
-IMAGE_FSTYPES += "${@bb.utils.contains('DISTRO_FEATURES', 'sota', 'ostreepush garagesign garagecheck ota-ext4 wic', ' ', d)}"
+IMAGE_FSTYPES += "${@bb.utils.contains('DISTRO_FEATURES', 'sota', 'ostreepush garagesign garagecheck ota-ext4', ' ', d)}"
 IMAGE_FSTYPES += "${@bb.utils.contains('BUILD_OSTREE_TARBALL', '1', 'ostree.tar.bz2', ' ', d)}"
 IMAGE_FSTYPES += "${@bb.utils.contains('BUILD_OTA_TARBALL', '1', 'ota.tar.xz', ' ', d)}"
 

--- a/classes/sota_m3ulcb.bbclass
+++ b/classes/sota_m3ulcb.bbclass
@@ -10,3 +10,5 @@ UBOOT_MACHINE:sota = "${@d.getVar('SOC_FAMILY').split(':')[1]}_ulcb_defconfig"
 
 PREFERRED_RPROVIDER_network-configuration ?= "connman"
 IMAGE_INSTALL:append:sota = " network-configuration "
+
+IMAGE_FSTYPES += "wic"

--- a/classes/sota_porter.bbclass
+++ b/classes/sota_porter.bbclass
@@ -9,3 +9,5 @@ UBOOT_MACHINE:sota = "porter_config"
 
 PREFERRED_RPROVIDER_network-configuration ?= "connman"
 IMAGE_INSTALL:append:sota = " network-configuration "
+
+IMAGE_FSTYPES += "wic"

--- a/classes/sota_qemux86-64.bbclass
+++ b/classes/sota_qemux86-64.bbclass
@@ -1,5 +1,3 @@
-IMAGE_FSTYPES:remove = "wic"
-
 # U-Boot support for SOTA
 PREFERRED_PROVIDER_virtual/bootloader_sota = "u-boot"
 UBOOT_MACHINE:sota = "qemu-x86_defconfig"


### PR DESCRIPTION
While most boards will indeed use wic format for images, it is not
something that is strictly required when using sota, as we do have
some BSPs that require only the ext4 image instead (e.g. tegra).

Wic should be included, when needed, at the machine config instead (or
via sota_<machine>.bbclass).

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>