### PR TITLE
ostree: adjust 0001-ostree-pull-set-request-timeout.patch

### DIFF
--- a/recipes-extended/ostree/ostree/0001-ostree-pull-set-request-timeout.patch
+++ b/recipes-extended/ostree/ostree/0001-ostree-pull-set-request-timeout.patch
@@ -1,4 +1,4 @@
-From 8f076eb377f3345e1df3302930456c7575d0dc89 Mon Sep 17 00:00:00 2001
+From cc446a8c7b2a7bc67875459d6e5c2f3312c3ca1f Mon Sep 17 00:00:00 2001
 From: Mike Sul <mike.sul@foundries.io>
 Date: Sat, 3 Jul 2021 20:37:08 -0300
 Subject: [PATCH] ostree-fetcher-curl: set a timeout for an overall request
@@ -6,16 +6,17 @@ Subject: [PATCH] ostree-fetcher-curl: set a timeout for an overall request
 
 Signed-off-by: Mike Sul <mike.sul@foundries.io>
 Signed-off-by: Ricardo Salveti <ricardo@foundries.io>
+
 ---
  src/libostree/ostree-fetcher-curl.c | 9 +++++++++
  1 file changed, 9 insertions(+)
 
 diff --git a/src/libostree/ostree-fetcher-curl.c b/src/libostree/ostree-fetcher-curl.c
-index d6534b46..1253da29 100644
+index 0ce3ff00..8965a407 100644
 --- a/src/libostree/ostree-fetcher-curl.c
 +++ b/src/libostree/ostree-fetcher-curl.c
-@@ -891,6 +891,15 @@ initiate_next_curl_request (FetcherRequest *req,
-   curl_easy_setopt (req->easy, CURLOPT_HEADERDATA, task);
+@@ -817,6 +817,15 @@ initiate_next_curl_request (FetcherRequest *req,
+   curl_easy_setopt (req->easy, CURLOPT_WRITEDATA, task);
    curl_easy_setopt (req->easy, CURLOPT_PROGRESSDATA, task);
  
 +  /* set a request timeout, make sure it's not 0, otherwise an overall ostree pull session might hang */
@@ -30,6 +31,3 @@ index d6534b46..1253da29 100644
    CURLMcode multi_rc = curl_multi_add_handle (self->multi, req->easy);
    g_assert (multi_rc == CURLM_OK);
  }
--- 
-2.32.0
-


### PR DESCRIPTION
* adjust for 2020.7 version used in gatesgarth
  hardknott is using 2021.1, honister 2021.3