### PR TITLE
image_types_ota.bbclass: add support for none as OSTREE_BOOTLOADER

### DIFF
--- a/classes/image_types_ota.bbclass
+++ b/classes/image_types_ota.bbclass
@@ -25,6 +25,8 @@ IMAGE_CMD:ota () {
 		mkdir -p ${OTA_SYSROOT}/boot/syslinux
 		touch ${OTA_SYSROOT}/boot/loader/syslinux.cfg
 		ln -s ../loader/syslinux.cfg ${OTA_SYSROOT}/boot/syslinux/syslinux.cfg
+	elif [ "${OSTREE_BOOTLOADER}" = "none" ]; then
+		ostree config --repo=${OTA_SYSROOT}/ostree/repo set sysroot.bootloader none
 	else
 		bbfatal "Invalid bootloader: ${OSTREE_BOOTLOADER}"
 	fi


### PR DESCRIPTION
Ostree has support for deploying without any bootloader specifics, by
simply deploying just the configuration files under
/boot/loader/entries, following the Boot Loader Specification
implementation.

This is useful for bootloaders other than grub and u-boot, as they can
just implement reading/parsing BLS configs instead (e.g. systemd-boot).

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>