### PR TITLE
asn1c: use BSD-2-Clause instead of ambiguous BSD

### DIFF
--- a/recipes-sota/asn1c/asn1c.bb
+++ b/recipes-sota/asn1c/asn1c.bb
@@ -2,7 +2,7 @@ SUMMARY = "ASN.1 to C compiler"
 DESCRIPTION = "Generates serialization routines from ASN.1 schemas"
 HOMEPAGE = "http://lionet.info/asn1c"
 SECTION = "base"
-LICENSE = "BSD"
+LICENSE = "BSD-2-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=ee8bfaaa7d71cf3edb079475e6716d4b"
 
 inherit autotools native


### PR DESCRIPTION
* fixes:
  ERROR: asn1c-native-0.9.28-r0 do_populate_lic: QA Issue: asn1c-native: No generic license file exists for: BSD in any provider [license-exists]

  after ambiguous BSD license text was removed in:
  https://git.openembedded.org/openembedded-core/commit/?h=kirkstone&id=14d4c007c49652d836d325a12bdbcd3bfa42e6d5

Signed-off-by: Martin Jansa <martin2.jansa@lgepartner.com>