### PR TITLE
image_types_ota: use += when setting task depends for image_ota_ext4

### DIFF
--- a/classes/image_types_ota.bbclass
+++ b/classes/image_types_ota.bbclass
@@ -87,5 +87,5 @@ IMAGE_CMD:ota-ext4 () {
 	ln -sf ${STAGING_DIR_NATIVE}${base_sbindir_native}/fsck.ext4 ${STAGING_DIR_NATIVE}${base_sbindir_native}/fsck.ota-ext4
 	oe_mkext234fs ota-ext4 ${EXTRA_IMAGECMD}
 }
-do_image_ota_ext4[depends] = "e2fsprogs-native:do_populate_sysroot"
+do_image_ota_ext4[depends] += "e2fsprogs-native:do_populate_sysroot"
 do_image_wic[depends] += "${@bb.utils.contains('DISTRO_FEATURES', 'sota', '%s:do_image_ota_ext4' % d.getVar('PN'), '', d)}"


### PR DESCRIPTION
This allows external layers to include additional task dependencies for
additional customizations done via IMAGE_CMD:ota-ext4:append.

No functional changes, default dependency list stays the same.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>