### PR TITLE
image_types_ostree: show the errorcode on the push failed warning

### DIFF
--- a/classes/image_types_ostree.bbclass
+++ b/classes/image_types_ostree.bbclass
@@ -258,7 +258,7 @@ IMAGE_CMD:garagesign () {
                 push_success=1
                 break
             else
-                bbwarn "Push to garage repository has failed, retrying"
+                bbwarn "Push to garage repository has failed with errcode ${errcode}, retrying"
             fi
         done
         rm -rf ${GARAGE_SIGN_REPO}


### PR DESCRIPTION
Signed-off-by: Jose Quaresma <jose.quaresma@foundries.io>
(cherry picked from commit 286d4ea374ee2c60d1576fada8bbe100a6566a4d)
Signed-off-by: Jose Quaresma <jose.quaresma@foundries.io>