### PR TITLE
image_types_ostree: use bbfatal_log when do_image_garagesign fails

### DIFF
--- a/classes/image_types_ostree.bbclass
+++ b/classes/image_types_ostree.bbclass
@@ -264,7 +264,7 @@ IMAGE_CMD:garagesign () {
         rm -rf ${GARAGE_SIGN_REPO}
 
         if [ "$push_success" -ne "1" ]; then
-            bbfatal "Couldn't push to garage repository"
+            bbfatal_log "Couldn't push to garage repository"
         fi
     fi
 }


### PR DESCRIPTION
The bbfatal_log is like bbfatal, except prevents the suppression of the error log by bitbake's UI.

When 'garage-sign targets push' fails all attempts is better to show their sterr+stdout logs.

This will change the error log from this:

```
ERROR: lmp-base-console-image-1.0-r0 do_image_garagesign: garage-sign fatal error with code 1
ERROR: lmp-base-console-image-1.0-r0 do_image_garagesign: ExecutionError('/oe/build/tmp/work/intel_corei7_64-lmp-linux/lmp-base-console-image/1.0-r0/temp/run.do_image_garagesign.1590854', 1, None, None)
ERROR: Logfile of failure stored in: /oe/build/tmp/work/intel_corei7_64-lmp-linux/lmp-base-console-image/1.0-r0/temp/log.do_image_garagesign.1590854
ERROR: Task (/oe/layers/meta-lmp/meta-lmp-base/recipes-samples/images/lmp-base-console-image.bb:do_image_garagesign) failed with exit code '1'
```


To this:

```
ERROR: lmp-base-console-image-1.0-r0 do_image_garagesign: garage-sign fatal error with code 1
ERROR: lmp-base-console-image-1.0-r0 do_image_garagesign: ExecutionError('/oe/build/tmp/work/intel_corei7_64-lmp-linux/lmp-base-console-image/1.0-r0/temp/run.do_image_garagesign.1590854', 1, None, None)
ERROR: Logfile of failure stored in: /oe/build/tmp/work/intel_corei7_64-lmp-linux/lmp-base-console-image/1.0-r0/temp/log.do_image_garagesign.1590854
Log data follows:
| DEBUG: Executing python function extend_recipe_sysroot
.
.
.
| DEBUG: Executing shell function do_image_garagesign | Usage:  [options]
|
|   -h | -help         print this message
|   -v | -verbose      this runner is chattier
|   -d | -debug        set sbt log level to debug
|   -no-version-check  Don't run the java version check.
|   -main <classname>  Define a custom main class
|   -jvm-debug <port>  Turn on JVM debugging, open at the given port.
|
|   # java version (default: java from PATH, currently )
|   -java-home <path>         alternate JAVA_HOME
|
|   # jvm options and output control
|   JAVA_OPTS          environment variable, if unset uses ""
|   -Dkey=val          pass -Dkey=val directly to the java runtime
|   -J-X               pass option -X directly to the java runtime
|                      (-J is stripped)
|
|   # special option
|   --                 To stop parsing built-in commands from the rest of the command-line.
|                      e.g.) enabling debug and sending -d as app argument
|                      $ ./start-script -d -- -d
|
| In the case of duplicated or conflicting options, basically the order above
| shows precedence: JAVA_OPTS lowest, command line options highest except "--".
| Available main classes:
|       com.advancedtelematic.tuf.cli.Cli
| ERROR: garage-sign fatal error with code 1
| WARNING: exit code 1 from a shell command.
ERROR: Task (/oe/layers/meta-lmp/meta-lmp-base/recipes-samples/images/lmp-base-console-image.bb:do_image_garagesign) failed with exit code '1'
```

For the following change:
```
 --- a/classes/image_types_ostree.bbclass
 +++ b/classes/image_types_ostree.bbclass
 @@ -183,6 +183,10 @@ do_image_garagesign[depends] += "unzip-native:do_populate_sysroot" | # garage-sign simultaneously for two images often causes problems. |  do_image_garagesign[lockfiles] += "${DEPLOY_DIR_IMAGE}/garagesign.lock" |  IMAGE_CMD:garagesign () {
 +
 +    garage-sign -h || errcode=$?
 +    bbfatal "garage-sign fatal error with code ${errcode}"
 +
      if [ -n "${SOTA_PACKED_CREDENTIALS}" ]; then
          # if credentials are issued by a server that doesn't support offline signing, exit silently
          unzip -p ${SOTA_PACKED_CREDENTIALS} root.json targets.pub targets.sec tufrepo.url 2>&1 >/dev/null || exit 0
```

Signed-off-by: Jose Quaresma <jose.quaresma@foundries.io>