### PR TITLE
image_types_ostree: use bbfatal_log when do_image_garagesign fails

### DIFF
--- a/classes/image_types_ostree.bbclass
+++ b/classes/image_types_ostree.bbclass
@@ -264,7 +264,7 @@ IMAGE_CMD:garagesign () {
         rm -rf ${GARAGE_SIGN_REPO}
 
         if [ "$push_success" -ne "1" ]; then
-            bbfatal "Couldn't push to garage repository"
+            bbfatal_log "Couldn't push to garage repository"
         fi
     fi
 }


### PR DESCRIPTION
The bbfatal_log is like bbfatal, except prevents the suppression of the error log by bitbake's UI.

When 'garage-sign targets push' fails all attempts is better to show their sterr+stdout logs.

Signed-off-by: Jose Quaresma <jose.quaresma@foundries.io>
(cherry picked from commit 1e26bf9dc006e006c981ed4781ae5df32d817217)
Signed-off-by: Jose Quaresma <jose.quaresma@foundries.io>