### PR TITLE
Improve the garage-sign targets push resilience

### DIFF
--- a/classes/image_types_ostree.bbclass
+++ b/classes/image_types_ostree.bbclass
@@ -11,6 +11,8 @@ OSTREE_UPDATE_SUMMARY ??= "0"
 
 BUILD_OSTREE_TARBALL ??= "1"
 
+GARAGE_PUSH_RETRIES ??= "3"
+
 SYSTEMD_USED = "${@oe.utils.ifelse(d.getVar('VIRTUAL-RUNTIME_init_manager') == 'systemd', 'true', '')}"
 
 IMAGE_CMD_TAR = "tar --xattrs --xattrs-include=*"
@@ -229,7 +231,7 @@ IMAGE_CMD:garagesign () {
             target_expiry="--expire-after 1M"
         fi
 
-        for push_retries in $( seq 3 ); do
+        for push_retries in $( seq ${GARAGE_PUSH_RETRIES} ); do
             garage-sign targets pull --repo tufrepo \
                                      --home-dir ${GARAGE_SIGN_REPO}
             garage-sign targets add --repo tufrepo \
@@ -258,7 +260,7 @@ IMAGE_CMD:garagesign () {
                 push_success=1
                 break
             else
-                bbwarn "Push to garage repository has failed with errcode ${errcode}, retrying"
+                bbwarn "Push to garage repository has failed with errcode ${errcode}, retrying ${push_retries}/${GARAGE_PUSH_RETRIES}"
             fi
         done
         rm -rf ${GARAGE_SIGN_REPO}

--- a/classes/image_types_ostree.bbclass
+++ b/classes/image_types_ostree.bbclass
@@ -12,6 +12,7 @@ OSTREE_UPDATE_SUMMARY ??= "0"
 BUILD_OSTREE_TARBALL ??= "1"
 
 GARAGE_PUSH_RETRIES ??= "3"
+GARAGE_PUSH_RETRIES_SLEEP ??= "0"
 
 SYSTEMD_USED = "${@oe.utils.ifelse(d.getVar('VIRTUAL-RUNTIME_init_manager') == 'systemd', 'true', '')}"
 
@@ -261,6 +262,12 @@ IMAGE_CMD:garagesign () {
                 break
             else
                 bbwarn "Push to garage repository has failed with errcode ${errcode}, retrying ${push_retries}/${GARAGE_PUSH_RETRIES}"
+                if [ "${GARAGE_PUSH_RETRIES_SLEEP}" -ne "0" ]; then
+                    ramdom="$(date +%s%N | cut -b10-19)"
+                    sleep="$(expr ${ramdom} % ${GARAGE_PUSH_RETRIES_SLEEP} + 1)"
+                    bbdebug 1 "Push to garage repository in ${sleep} seconds"
+                    sleep ${sleep}
+                fi
             fi
         done
         rm -rf ${GARAGE_SIGN_REPO}


### PR DESCRIPTION
- image_types_ostree: introduce GARAGE_PUSH_RETRIES

This add the possibility to change the number of retries
of the "garage-sign targets push"

- image_types_ostree: introduce GARAGE_PUSH_RETRIES_SLEEP

This add the possibility to sleep a maximum defined random
time after "garage-sign targets push" fails
