### PR TITLE
sota_sanity.bbclass: don't use copy_data()

### DIFF
--- a/classes/sota_sanity.bbclass
+++ b/classes/sota_sanity.bbclass
@@ -97,7 +97,7 @@ sota_check_sanity_eventhandler[eventmask] = "bb.event.SanityCheck"
 
 python sota_check_sanity_eventhandler() {
     if bb.event.getName(e) == "SanityCheck":
-        sanity_data = copy_data(e)
+        sanity_data = bb.data.createCopy(e.data)
         if e.generateevents:
             sanity_data.setVar("SANITY_USE_EVENTS", "1")
         reparse = sota_check_sanity(sanity_data)


### PR DESCRIPTION
* fixes: https://github.com/uptane/meta-updater/issues/60

  meta-updater/classes/sota_sanity.bbclass", line 100, in defaultsota_check_sanity_eventhandler(e=<bb.event.SanityCheck object at 0x7fa32faedf30>): if bb.event.getName(e) == "SanityCheck":
      >        sanity_data = copy_data(e)
               if e.generateevents:
  NameError: name 'copy_data' is not defined

  copy_data function was removed in: https://git.openembedded.org/openembedded-core/commit/?id=d3eb4531aae28a07cb7e52ed5fe1102445d2effd