### PR TITLE
sota_sanity.bbclass: don't use copy_data()

### DIFF
--- a/classes/sota_sanity.bbclass
+++ b/classes/sota_sanity.bbclass
@@ -97,7 +97,7 @@ sota_check_sanity_eventhandler[eventmask] = "bb.event.SanityCheck"
 
 python sota_check_sanity_eventhandler() {
     if bb.event.getName(e) == "SanityCheck":
-        sanity_data = copy_data(e)
+        sanity_data = bb.data.createCopy(e.data)
         if e.generateevents:
             sanity_data.setVar("SANITY_USE_EVENTS", "1")
         reparse = sota_check_sanity(sanity_data)


### PR DESCRIPTION
The oe-core change got backported today to langdale and kirkstone:
https://git.openembedded.org/openembedded-core/commit/?h=kirkstone&id=06e088ef6e961f05ca600612adcc71bff91f09be

so we need the changes from https://github.com/uptane/meta-updater/pull/61 to be applied there as well.