### PR TITLE
image_types_ostree: remove var/lib and var/cache before var

### DIFF
--- a/classes/image_types_ostree.bbclass
+++ b/classes/image_types_ostree.bbclass
@@ -43,6 +43,9 @@ IMAGE_CMD:ostree () {
     if [ -d var/local ]; then
         mv var/local var-local
     fi
+    # var/lib and var/cache requires special handling as they are needed by do_rootfs
+    ostree_rmdir_helper var/lib
+    ostree_rmdir_helper var/cache
     ostree_rmdir_helper var
     mkdir var
     if [ -d var/local ]; then


### PR DESCRIPTION
Both requires special handling as these directories are required by the do_rootfs task (used while bootstrapping the image via packages), and can't be removed via recipes.

This fixes the var/lib and var/cache warnings when removing var.