### PR TITLE
Backport [kirkstone]: image_types_ostree: remove var/lib and var/cache before var

### DIFF
--- a/classes/image_types_ostree.bbclass
+++ b/classes/image_types_ostree.bbclass
@@ -43,6 +43,9 @@ IMAGE_CMD:ostree () {
     if [ -d var/local ]; then
         mv var/local var-local
     fi
+    # var/lib and var/cache requires special handling as they are needed by do_rootfs
+    ostree_rmdir_helper var/lib
+    ostree_rmdir_helper var/cache
     ostree_rmdir_helper var
     mkdir var
     if [ -d var/local ]; then


### PR DESCRIPTION
Backport https://github.com/uptane/meta-updater/pull/71