### PR TITLE
nfs-utils: update the systemd tmpfiles and fix the warning

### DIFF
--- a/recipes-connectivity/nfs-utils/nfs-utils/tmpfiles.conf
+++ b/recipes-connectivity/nfs-utils/nfs-utils/tmpfiles.conf
@@ -1,5 +1,8 @@
 d /var/lib/nfs 0755 root root -
-d /var/lib/nfs/v4recovery 0755 root root -
+f /var/lib/nfs/etab 0644 rpcuser rpcuser -
 d /var/lib/nfs/statd 0755 rpcuser rpcuser -
 d /var/lib/nfs/statd/sm 0700 rpcuser rpcuser -
+f /var/lib/nfs/statd/state 0644 rpcuser rpcuser -
 d /var/lib/nfs/statd/sm.bak 0700 rpcuser rpcuser -
+f /var/lib/nfs/rmtab 0644 rpcuser rpcuser -
+d /var/lib/nfs/v4recovery 0755 root root -

--- a/recipes-connectivity/nfs-utils/nfs-utils_%.bbappend
+++ b/recipes-connectivity/nfs-utils/nfs-utils_%.bbappend
@@ -4,6 +4,18 @@ SRC_URI:append:sota = " file://tmpfiles.conf"
 
 do_install:append:sota () {
     install -D -m 0644 ${WORKDIR}/tmpfiles.conf ${D}${nonarch_libdir}/tmpfiles.d/nfs-utils.conf
+
+    rm -v \
+        ${D}/var/lib/nfs/etab \
+        ${D}/var/lib/nfs/statd/state \
+        ${D}/var/lib/nfs/rmtab
+
+    rmdir -v \
+        ${D}/var/lib/nfs/statd/sm.bak \
+        ${D}/var/lib/nfs/statd/sm \
+        ${D}/var/lib/nfs/statd \
+        ${D}/var/lib/nfs/v4recovery \
+        ${D}/var/lib/nfs
 }
 
 FILES:${PN} += "${nonarch_libdir}/tmpfiles.d/nfs-utils.conf"


### PR DESCRIPTION
```
WARNING: lmp-base-console-image-1.0-r0 do_image_ostree: Data in 'var/lib' directory is not preserved by OSTree. Consider moving it under '/usr' | var/lib/nfs
var/lib/nfs/etab
var/lib/nfs/statd
var/lib/nfs/statd/sm
var/lib/nfs/statd/state
var/lib/nfs/statd/sm.bak
var/lib/nfs/rmtab
var/lib/nfs/v4recovery
```