### PR TITLE
fit-conf: fix u-boot boot fail

### DIFF
--- a/recipes-sota/fit-conf/fit-conf.bb
+++ b/recipes-sota/fit-conf/fit-conf.bb
@@ -9,11 +9,11 @@ do_install() {
 	echo -n "fit_conf=" >${D}${libdir}/fit_conf
 
 	if [ -n ${SOTA_MAIN_DTB} ]; then
-		echo -n "#conf@${SOTA_MAIN_DTB}" >> ${D}${libdir}/fit_conf
+		echo -n "#conf-${SOTA_MAIN_DTB}" >> ${D}${libdir}/fit_conf
 	fi
 
 	for ovrl in ${SOTA_DT_OVERLAYS}; do
-		echo -n "#conf@overlays_${ovrl}" >> ${D}${libdir}/fit_conf
+		echo -n "#conf-overlays_${ovrl}" >> ${D}${libdir}/fit_conf
 	done
 
 	for conf_frag in ${SOTA_EXTRA_CONF_FRAGS}; do


### PR DESCRIPTION
On board using a fitImage, poky's upstream change from the following commit:
https://git.yoctoproject.org/poky/commit/?id=ab6b5e97cebe19938baa403da6307ca320294b3a
inserted a regression of the fit-conf.bb recipe.
Causing a U-boot boot fault displaying this type of message:
```
  Could not find configuration node
  ERROR: can't get kernel image!
  Unknown command '!' - try 'help'
  resetting ...
```
fitImage configuration labels are now prefixed with conf- instead of conf@.
This commit incorporates this modification for the fit-conf.bb recipe.

fix #75 
