### PR TITLE
IMAGE_NAME_SUFFIX changed upstream in oe-core

### DIFF
--- a/classes/image_types_ostree.bbclass
+++ b/classes/image_types_ostree.bbclass
@@ -17,7 +17,7 @@ GARAGE_PUSH_RETRIES_SLEEP ??= "0"
 SYSTEMD_USED = "${@oe.utils.ifelse(d.getVar('VIRTUAL-RUNTIME_init_manager') == 'systemd', 'true', '')}"
 
 IMAGE_CMD_TAR = "tar --xattrs --xattrs-include=*"
-CONVERSION_CMD:tar = "touch ${IMGDEPLOYDIR}/${IMAGE_NAME}${IMAGE_NAME_SUFFIX}.${type}; ${IMAGE_CMD_TAR} --numeric-owner -cf ${IMGDEPLOYDIR}/${IMAGE_NAME}${IMAGE_NAME_SUFFIX}.${type}.tar -C ${TAR_IMAGE_ROOTFS} . || [ $? -eq 1 ]"
+CONVERSION_CMD:tar = "touch ${IMGDEPLOYDIR}/${IMAGE_NAME}.${type}; ${IMAGE_CMD_TAR} --numeric-owner -cf ${IMGDEPLOYDIR}/${IMAGE_NAME}.${type}.tar -C ${TAR_IMAGE_ROOTFS} . || [ $? -eq 1 ]"
 CONVERSIONTYPES:append = " tar"
 
 TAR_IMAGE_ROOTFS:task-image-ostree = "${OSTREE_ROOTFS}"

--- a/recipes-core/images/initramfs-ostree-image.bb
+++ b/recipes-core/images/initramfs-ostree-image.bb
@@ -5,6 +5,7 @@ PACKAGE_INSTALL = "ostree-switchroot ostree-initrd busybox base-passwd ${ROOTFS_
 
 SYSTEMD_DEFAULT_TARGET = "initrd.target"
 
+IMAGE_NAME_SUFFIX = ""
 # Do not pollute the initrd image with rootfs features
 IMAGE_FEATURES = ""
 


### PR DESCRIPTION
- image_types_ostree: IMAGE_NAME_SUFFIX is now directly included
_The IMAGE_NAME_SUFFIX is now directly included in both IMAGE_NAME and IMAGE_LINK_NAME._

- initramfs-ostree-image: IMAGE_NAME_SUFFIX should by emptry for initramfs
_INITRAMFS_IMAGE_NAME stay as before but it assumes that all
images used as initramfs will set IMAGE_NAME_SUFFIX to empty._

https://git.yoctoproject.org/poky/commit/?id=6f6c79029bc2020907295858449c725952d560a1
