### PR TITLE
fix build error : 'uint8_t' does not name a type

### DIFF
--- a/recipes-sota/aktualizr/aktualizr_git.bb
+++ b/recipes-sota/aktualizr/aktualizr_git.bb
@@ -27,6 +27,7 @@ SRC_URI = " \
   file://aktualizr-serialcan.service \
   file://aktualizr-tmpfiles.conf \
   file://run-ptest \
+  file://0001-fix-build-error-uint8_t-does-not-name-a-type.patch \
   ${@ d.expand("https://tuf-cli-releases.ota.here.com/cli-${GARAGE_SIGN_PV}.tgz;unpack=0;name=garagesign") if not oe.types.boolean(d.getVar('GARAGE_SIGN_AUTOVERSION')) else ''} \
   "
 

--- a/recipes-sota/aktualizr/files/0001-fix-build-error-uint8_t-does-not-name-a-type.patch
+++ b/recipes-sota/aktualizr/files/0001-fix-build-error-uint8_t-does-not-name-a-type.patch
@@ -1,0 +1,24 @@
+From d12f3cb5ed86c546248732ad6348824ee77a8841 Mon Sep 17 00:00:00 2001
+From: dudengke <dengke.du@ucas.com.cn>
+Date: Wed, 12 Jul 2023 15:25:19 +0800
+Subject: [PATCH] fix build error : 'uint8_t' does not name a type
+
+---
+ src/libaktualizr-posix/asn1/asn1-cer.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/libaktualizr-posix/asn1/asn1-cer.h b/src/libaktualizr-posix/asn1/asn1-cer.h
+index 4ae23f4b..26f9a8ae 100644
+--- a/src/libaktualizr-posix/asn1/asn1-cer.h
++++ b/src/libaktualizr-posix/asn1/asn1-cer.h
+@@ -3,6 +3,7 @@
+ 
+ #include <stdexcept>
+ #include <string>
++#include <stdint.h>
+ 
+ // Limitations:
+ //   - Maximal supported integer width of 32 bits
+-- 
+2.25.1
+


### PR DESCRIPTION
My environment:
    meta-updater: master branch [c10f9f]
    yocto poky: master branch [303421]
    ARCH: arm64

When I take : bitbake aktualizr, output error that said uint8_t does not name a type. So add the header file stdint.h to asn1-cer.h

Upstream-Status: Pending