### PR TITLE
aktualizr: bump SRCREV

### DIFF
--- a/recipes-sota/aktualizr/aktualizr_git.bb
+++ b/recipes-sota/aktualizr/aktualizr_git.bb
@@ -33,7 +33,7 @@ SRC_URI = " \
 SRC_URI[garagesign.md5sum] = "584cd16aa7824e34b593dae63796466b"
 SRC_URI[garagesign.sha256sum] = "c7d5fdceef3e815363e3aa398c38643ca213f9b7f66d50f55c76a66cb74565d2"
 
-SRCREV = "eced3900754b51273733c66588ca44c44ba03b2c"
+SRCREV = "c90723717a4a196cfb9d923dbcd48c5d6031d2c4"
 BRANCH ?= "master"
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
Update the SRCREV to fix a build failure ('uint8_t' does not name a type) when using poky master branch.

c90723717 (HEAD -> master, origin/master, origin/HEAD) Merge pull request #105 from uptane/merge-upstream-docs 7dff8e1c2 Fixed coverage and static checks jobs (#1837) d35e774c0 Fixed libOstree links (#1833)
efd939295 Merge pull request #101 from uptane/fix-shellcheck-complaint b2ee72ebf Merge pull request #102 from DengkeDu/fix-build-error-v2 05b1af5e0 aktualizr: fix build error 'uint8_t' does not name a type 317f2ee65 (origin/fix-shellcheck-complaint) Remove leftover cruft from load tests. 69dfff995 Fix shellcheck complaint that somehow didn't show up until now. 60e2ffbff Merge pull request #96 from cajun-rat/multibyte-part1 b32833489 Fix test flake by picking a random port
28ed95cd9 Add tests for non-ascii targets
6eacb8ac3 Refactor Implementation of HttpFake and MetaFake out of header file 3b92fb0a8 Decode URLs in HttpFake
c54afdd57 Merge pull request #94 from uptane/docs/OTA-5642/update-targets-options 8afa20446 OTA-5642 update targets upload and add-uploaded options 762741ac6 Merge pull request #93 from uptane/document-targets.json-size-limit 16b0d5005 OTA-6069 document targets.json size limit 0622ad789 Merge pull request #92 from uptane/aktualizr-info-root-version 342d176a9 aktualizr-info: Allow specifying the Root metadata version to output. 86cad5a1d Merge pull request #91 from uptane/docs/upstream 69efebebc OTA-5352 add page about how to add/remove key, set threshold 1420ad5f5 OTA-5352 add page about how to add/remove key, set threshold f039b6f82 Revert "OTA-5352 add page about how to add/remove key, set threshold" 377aad27e Merge pull request #90 from uptane/add-remove-targets-key 04765058a OTA-5352 add page about how to add/remove key, set threshold 0b4e2e71a Merge pull request #88 from uptane/feat/event-sending-improvements dc5ede14d Fix clang-tidy complaints.
57bae6892 Send smaller payload or drop if 413
b49975c1b Limit event number sent in a single request e6df198cf Optionally limit event number to fetch
45d033679 Merge pull request #84 from uptane/feat/improve-error-logging f6816a1b9 Stop emitting LOG_ERROR messages when verifying local metadata 2d6b8a57f Merge pull request #73 from uptane/tuf-test-vectors-uptane-namespace 8a9595b5b Manually fetch the submodules in github CI. 4fb44d770 Use main instead of master; it's newer.
b4513018e Bump tuf-test-vectors and switch to uptane namespace. bb385161d Merge pull request #86 from uptane/docs-port afdf96a59 Add login to dockerhub
28b1da02d Changed not relevant link from Troubleshooting BSP Integration & Rollbacks pages (#1818) 2de3b690f Merge pull request #85 from uptane/fix/macos-build 1a44c2a19 (origin/fix/macos-build) Minor fixes to build correctly on MacOS 67596b0b7 Merge pull request #82 from cajun-rat/bug/storekeys b7b3b287c Only write ManagedSecondary keys once
7b015f9b3 Rename struct stat to 'stat_buf' from 'st' 1f855fe1f Merge pull request #81 from uptane/fix-U-Boot-url-master e0286749c changed not relevant url
fa12aaaae Merge pull request #78 from uptane/fix/77/arm-int64_t 7594cd55d Merge pull request #79 from uptane/feature/AddDefaultPKCS11ArmPath f1002f440 Added default path for pkcs11 for arm.
846edc038 Attempt to fix int conversion error found on ARM.