### PR TITLE
sota.inc: add meta-networking to the layers

### DIFF
--- a/conf/include/bblayers/sota.inc
+++ b/conf/include/bblayers/sota.inc
@@ -1,4 +1,5 @@
 BBLAYERS += "${METADIR}/meta-updater"
 BBLAYERS += "${METADIR}/meta-openembedded/meta-filesystems"
+BBLAYERS += "${METADIR}/meta-openembedded/meta-networking"
 BBLAYERS += "${METADIR}/meta-openembedded/meta-oe"
 BBLAYERS += "${METADIR}/meta-openembedded/meta-python"


### PR DESCRIPTION
Fix ERROR: Layer 'filesystems-layer' depends on layer 'networking-layer', but this layer is not enabled in your configuration