### PR TITLE
ostree-kernel-initramfs: fix kernel rebuild 

### DIFF
--- a/classes/sota.bbclass
+++ b/classes/sota.bbclass
@@ -55,3 +55,8 @@ SOTA_OVERRIDES_BLACKLIST = "ostree ota"
 SOTA_REQUIRED_VARIABLES = "OSTREE_REPO OSTREE_BRANCHNAME OSTREE_OSNAME OSTREE_BOOTLOADER OSTREE_BOOT_PARTITION GARAGE_SIGN_REPO GARAGE_TARGET_NAME"
 
 inherit sota_sanity sota_${SOTA_MACHINE}
+
+# required by ostree-kernel-initramfs
+kernel_do_deploy:append() {
+    install -m 0644 ${STAGING_KERNEL_BUILDDIR}/kernel-abiversion $deployDir
+}

--- a/recipes-sota/ostree-kernel-initramfs/ostree-kernel-initramfs_0.0.1.bb
+++ b/recipes-sota/ostree-kernel-initramfs/ostree-kernel-initramfs_0.0.1.bb
@@ -23,11 +23,11 @@ PACKAGE_ARCH = "${MACHINE_ARCH}"
 KERNEL_BUILD_ROOT = "${nonarch_base_libdir}/modules/"
 
 # There's nothing to do here, except install the artifacts where we can package them
-do_fetch[noexec] = "1"
-do_unpack[noexec] = "1"
-do_patch[noexec] = "1"
-do_configure[noexec] = "1"
-do_compile[noexec] = "1"
+deltask do_fetch
+deltask do_unpack
+deltask do_patch
+deltask do_configure
+deltask do_compile
 deltask do_populate_sysroot
 
 do_install() {

--- a/recipes-sota/ostree-kernel-initramfs/ostree-kernel-initramfs_0.0.1.bb
+++ b/recipes-sota/ostree-kernel-initramfs/ostree-kernel-initramfs_0.0.1.bb
@@ -31,7 +31,8 @@ deltask do_compile
 deltask do_populate_sysroot
 
 do_install() {
-    kerneldir=${D}${KERNEL_BUILD_ROOT}${KERNEL_VERSION}
+    kernelver="$(cat ${DEPLOY_DIR_IMAGE}/kernel-abiversion)"
+    kerneldir=${D}${KERNEL_BUILD_ROOT}$kernelver
     install -d $kerneldir
 
     cp ${DEPLOY_DIR_IMAGE}/${OSTREE_KERNEL} $kerneldir/vmlinuz
@@ -60,7 +61,6 @@ do_install() {
         fi
     fi
 }
-do_install[vardepsexclude] = "KERNEL_VERSION"
 INITRAMFS_IMAGE ?= ""
 do_install[depends] = "virtual/kernel:do_deploy ${@['${INITRAMFS_IMAGE}:do_image_complete', ''][d.getVar('INITRAMFS_IMAGE') == '']}"
 


### PR DESCRIPTION
The recipe ostree-kernel-initramfs currently  triggers a kernel rebuild because the module-base.bbclass explicitly requires it and the `noexec` used on the recipe still uses what is in the task `depends` flag
    
```
$ grep depends meta/classes-recipe/module-base.bbclass
do_configure[depends] += "make-mod-scripts:do_compile"
```
