### PR TITLE
image_types_ota: use a soft assignment for EXTRA_IMAGECMD:ota-ext4

### DIFF
--- a/classes/image_types_ota.bbclass
+++ b/classes/image_types_ota.bbclass
@@ -79,7 +79,7 @@ IMAGE_CMD:ota () {
 	echo "{\"${ostree_target_hash}\":\"${GARAGE_TARGET_NAME}-${target_version}\"}" > ${OTA_SYSROOT}/ostree/deploy/${OSTREE_OSNAME}/var/sota/import/installed_versions
 }
 
-EXTRA_IMAGECMD:ota-ext4 = "-L otaroot -i 4096 -t ext4"
+EXTRA_IMAGECMD:ota-ext4 ?= "-L otaroot -i 4096 -t ext4"
 IMAGE_TYPEDEP:ota-ext4 = "ota"
 IMAGE_ROOTFS:task-image-ota-ext4 = "${OTA_SYSROOT}"
 IMAGE_CMD:ota-ext4 () {


### PR DESCRIPTION
EXTRA_IMAGECMD is using hardcoded values like "-i 4096". Use a soft assignment to make it easier to override.
Currently, we can still override but we need to use more statements (:append / :remove). Hence it's less convenient.