### PR TITLE
image_types_ota: rely on FSTYPES to add do_image_wic dependency

### DIFF
--- a/classes/image_types_ota.bbclass
+++ b/classes/image_types_ota.bbclass
@@ -88,4 +88,4 @@ IMAGE_CMD:ota-ext4 () {
 	oe_mkext234fs ota-ext4 ${EXTRA_IMAGECMD}
 }
 do_image_ota_ext4[depends] += "e2fsprogs-native:do_populate_sysroot"
-do_image_wic[depends] += "${@bb.utils.contains('DISTRO_FEATURES', 'sota', '%s:do_image_ota_ext4' % d.getVar('PN'), '', d)}"
+do_image_wic[depends] += "${@bb.utils.contains('IMAGE_FSTYPES', 'ota-ext4', '%s:do_image_ota_ext4' % d.getVar('PN'), '', d)}"


### PR DESCRIPTION
Using FSTYPES to add the do_image_wic dependency instead of sota DISTRO_FEATURES. It allows to easily extend do_image_ota to other file systems. For instance, I successfully extended the class to use btrfs.

e.g. extending to btrfs will look like
inherit image_types_ota
[...]
do_image_wic[depends] += "${@bb.utils.contains('IMAGE_FSTYPES', 'ota-btrfs', '%s:do_image_ota_btrfs' % d.getVar('PN'), '', d)}"