### PR TITLE
image_types_ostree: fix logic to maintain /var/local contents (cherry pick from master branch)

### DIFF
--- a/classes/image_types_ostree.bbclass
+++ b/classes/image_types_ostree.bbclass
@@ -48,7 +48,7 @@ IMAGE_CMD:ostree () {
     ostree_rmdir_helper var/cache
     ostree_rmdir_helper var
     mkdir var
-    if [ -d var/local ]; then
+    if [ -d var-local ]; then
         mv var-local var/local
     fi
 


### PR DESCRIPTION
Commit 60c3f7267ff51caeaf6d74a5f445ee4bcf2f0ae8 added logic to specifically maintain the contents of /var/local into the generated image but a minor error in a condition prevented that from happening; here we fix that condition to meet the original goal.

See https://github.com/uptane/meta-updater/pull/69#discussion_r1523604247
