### PR TITLE
layer.conf: add scarthgap compatibility and drop some old releases

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -12,7 +12,7 @@ BBFILE_PRIORITY_sota = "7"
 LAYERDEPENDS_sota = "openembedded-layer"
 LAYERDEPENDS_sota += "meta-python"
 LAYERDEPENDS_sota += "filesystems-layer"
-LAYERSERIES_COMPAT_sota = "kirkstone langdale mickledore nanbield scarthgap"
+LAYERSERIES_COMPAT_sota = "nanbield scarthgap"
 
 SIGGEN_EXCLUDE_SAFE_RECIPE_DEPS += " \
   aktualizr-device-prov->aktualizr \

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -12,7 +12,7 @@ BBFILE_PRIORITY_sota = "7"
 LAYERDEPENDS_sota = "openembedded-layer"
 LAYERDEPENDS_sota += "meta-python"
 LAYERDEPENDS_sota += "filesystems-layer"
-LAYERSERIES_COMPAT_sota = "kirkstone langdale mickledore nanbield"
+LAYERSERIES_COMPAT_sota = "kirkstone langdale mickledore nanbield scarthgap"
 
 SIGGEN_EXCLUDE_SAFE_RECIPE_DEPS += " \
   aktualizr-device-prov->aktualizr \


### PR DESCRIPTION
The master branch is not more compatible with the kirkstone, at least [1] breaks invalidates compatibility.

Also remove the other intermediate releases as the master branch is mostly tested with the oe-core master.

[1] https://github.com/uptane/meta-updater/pull/78