### PR TITLE
recipes: fix S = "${WORKDIR}" no longer supported on master

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -12,7 +12,7 @@ BBFILE_PRIORITY_sota = "7"
 LAYERDEPENDS_sota = "openembedded-layer"
 LAYERDEPENDS_sota += "meta-python"
 LAYERDEPENDS_sota += "filesystems-layer"
-LAYERSERIES_COMPAT_sota = "nanbield scarthgap"
+LAYERSERIES_COMPAT_sota = "styhead"
 
 SIGGEN_EXCLUDE_SAFE_RECIPE_DEPS += " \
   aktualizr-device-prov->aktualizr \

--- a/recipes-connectivity/networkd-dhcp-conf/networkd-dhcp-conf.bb
+++ b/recipes-connectivity/networkd-dhcp-conf/networkd-dhcp-conf.bb
@@ -18,7 +18,8 @@ PR = "r1"
 REQUIRED_DISTRO_FEATURES = "systemd"
 RCONFLICTS:${PN} = "connman"
 
-S = "${WORKDIR}"
+S = "${WORKDIR}/sources"
+UNPACKDIR = "${S}"
 
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 
@@ -34,11 +35,11 @@ DEV_MATCH_DIRECTIVE ?= "Name=en*"
 
 do_install() {
     install -d ${D}/${systemd_unitdir}/network
-    install -m 0644 ${WORKDIR}/20-wired-dhcp.network ${D}${systemd_unitdir}/network
+    install -m 0644 ${UNPACKDIR}/20-wired-dhcp.network ${D}${systemd_unitdir}/network
     sed -i -e 's|@MATCH_DIRECTIVE@|${DEV_MATCH_DIRECTIVE}|g' ${D}${systemd_unitdir}/network/20-wired-dhcp.network
 
     install -d ${D}${sbindir}
-    install -m 0755 ${WORKDIR}/resolvconf-clean ${D}${sbindir}/resolvconf-clean
+    install -m 0755 ${UNPACKDIR}/resolvconf-clean ${D}${sbindir}/resolvconf-clean
     install -d ${D}${systemd_unitdir}/system
-    install -m 0644 ${WORKDIR}/clean-connman-symlink.service ${D}${systemd_unitdir}/system/clean-connman-symlink.service
+    install -m 0644 ${UNPACKDIR}/clean-connman-symlink.service ${D}${systemd_unitdir}/system/clean-connman-symlink.service
 }

--- a/recipes-connectivity/nfs-utils/nfs-utils_%.bbappend
+++ b/recipes-connectivity/nfs-utils/nfs-utils_%.bbappend
@@ -3,7 +3,7 @@ FILESEXTRAPATHS:prepend:sota := "${THISDIR}/${BPN}:"
 SRC_URI:append:sota = " file://tmpfiles.conf"
 
 do_install:append:sota () {
-    install -D -m 0644 ${WORKDIR}/tmpfiles.conf ${D}${nonarch_libdir}/tmpfiles.d/nfs-utils.conf
+    install -D -m 0644 ${UNPACKDIR}/tmpfiles.conf ${D}${nonarch_libdir}/tmpfiles.d/nfs-utils.conf
 
     rm -v \
         ${D}/var/lib/nfs/etab \

--- a/recipes-sota/aktualizr/aktualizr-collectd.bb
+++ b/recipes-sota/aktualizr/aktualizr-collectd.bb
@@ -8,11 +8,12 @@ RDEPENDS:${PN} = "collectd"
 
 SRC_URI = " file://aktualizr-collectd.conf"
 
-S = "${WORKDIR}"
+S = "${WORKDIR}/sources"
+UNPACKDIR = "${S}"
 
 do_install() {
     install -d ${D}${sysconfdir}/collectd.conf.d
-    install -m 0644 ${WORKDIR}/aktualizr-collectd.conf ${D}${sysconfdir}/collectd.conf.d/aktualizr.conf
+    install -m 0644 ${UNPACKDIR}/aktualizr-collectd.conf ${D}${sysconfdir}/collectd.conf.d/aktualizr.conf
 }
 
 FILES:${PN} = " \

--- a/recipes-sota/aktualizr/aktualizr_git.bb
+++ b/recipes-sota/aktualizr/aktualizr_git.bb
@@ -52,7 +52,7 @@ EXTRA_OECMAKE = "-DCMAKE_BUILD_TYPE=Release \
     ${@bb.utils.contains('PTEST_ENABLED', '1', '-DTESTSUITE_VALGRIND=on', '', d)} \
     -DBUILD_OSTREE=ON"
 
-GARAGE_SIGN_OPS = "${@ d.expand('-DGARAGE_SIGN_ARCHIVE=${WORKDIR}/cli-${GARAGE_SIGN_PV}.tgz') if not oe.types.boolean(d.getVar('GARAGE_SIGN_AUTOVERSION')) else ''}"
+GARAGE_SIGN_OPS = "${@ d.expand('-DGARAGE_SIGN_ARCHIVE=${UNPACKDIR}/cli-${GARAGE_SIGN_PV}.tgz') if not oe.types.boolean(d.getVar('GARAGE_SIGN_AUTOVERSION')) else ''}"
 PKCS11_ENGINE_PATH = "${libdir}/engines-3/pkcs11.so"
 
 PACKAGECONFIG ?= "${@bb.utils.filter('SOTA_CLIENT_FEATURES', 'hsm serialcan ubootenv', d)}"
@@ -98,14 +98,14 @@ do_install:append () {
     install -m 0644 ${S}/config/sota-secondary.toml ${D}/${libdir}/sota/sota-secondary.toml
     install -m 0644 ${S}/config/sota-uboot-env.toml ${D}/${libdir}/sota/sota-uboot-env.toml
     install -d ${D}${systemd_unitdir}/system
-    install -m 0644 ${WORKDIR}/aktualizr-secondary.service ${D}${systemd_unitdir}/system/aktualizr-secondary.service
+    install -m 0644 ${UNPACKDIR}/aktualizr-secondary.service ${D}${systemd_unitdir}/system/aktualizr-secondary.service
     install -m 0700 -d ${D}${libdir}/sota/conf.d
     install -m 0700 -d ${D}${sysconfdir}/sota/conf.d
     install -d ${D}${nonarch_libdir}/tmpfiles.d
-    install -m 0644 ${WORKDIR}/aktualizr-tmpfiles.conf ${D}${nonarch_libdir}/tmpfiles.d/aktualizr.conf
+    install -m 0644 ${UNPACKDIR}/aktualizr-tmpfiles.conf ${D}${nonarch_libdir}/tmpfiles.d/aktualizr.conf
 
     install -m 0755 -d ${D}${systemd_unitdir}/system
-    aktualizr_service=${@bb.utils.contains('SOTA_CLIENT_FEATURES', 'serialcan', '${WORKDIR}/aktualizr-serialcan.service', '${WORKDIR}/aktualizr.service', d)}
+    aktualizr_service=${@bb.utils.contains('SOTA_CLIENT_FEATURES', 'serialcan', '${UNPACKDIR}/aktualizr-serialcan.service', '${UNPACKDIR}/aktualizr.service', d)}
     install -m 0644 ${aktualizr_service} ${D}${systemd_unitdir}/system/aktualizr.service
 
     if ${@bb.utils.contains('PACKAGECONFIG', 'sota-tools', 'true', 'false', d)}; then
@@ -115,7 +115,7 @@ do_install:append () {
 
     # resource control
     install -d ${D}/${systemd_system_unitdir}/aktualizr.service.d
-    install -m 0644 ${WORKDIR}/10-resource-control.conf ${D}/${systemd_system_unitdir}/aktualizr.service.d
+    install -m 0644 ${UNPACKDIR}/10-resource-control.conf ${D}/${systemd_system_unitdir}/aktualizr.service.d
 
     sed -i -e 's|@CPU_WEIGHT@|${RESOURCE_CPU_WEIGHT}|g' \
            -e 's|@MEMORY_HIGH@|${RESOURCE_MEMORY_HIGH}|g' \

--- a/recipes-sota/config/aktualizr-auto-reboot.bb
+++ b/recipes-sota/config/aktualizr-auto-reboot.bb
@@ -11,9 +11,12 @@ SRC_URI = " \
             file://35-enable-auto-reboot.toml \
             "
 
+S = "${WORKDIR}/sources"
+UNPACKDIR = "${S}"
+
 do_install:append () {
     install -m 0700 -d ${D}${libdir}/sota/conf.d
-    install -m 0644 ${WORKDIR}/35-enable-auto-reboot.toml ${D}${libdir}/sota/conf.d/35-enable-auto-reboot.toml
+    install -m 0644 ${UNPACKDIR}/35-enable-auto-reboot.toml ${D}${libdir}/sota/conf.d/35-enable-auto-reboot.toml
 }
 
 FILES:${PN} = " \

--- a/recipes-sota/config/aktualizr-binary-pacman.bb
+++ b/recipes-sota/config/aktualizr-binary-pacman.bb
@@ -8,6 +8,9 @@ SRC_URI = "\
     file://10-pacman.toml \
     "
 
+S = "${WORKDIR}/sources"
+UNPACKDIR = "${S}"
+
 FILES:${PN} = " \
                 ${libdir}/sota/conf.d \
                 ${libdir}/sota/conf.d/10-pacman.toml \
@@ -17,5 +20,5 @@ PR = "1"
 
 do_install() {
     install -m 0700 -d ${D}${libdir}/sota/conf.d
-    install -m 0644 ${WORKDIR}/10-pacman.toml ${D}${libdir}/sota/conf.d/10-pacman.toml
+    install -m 0644 ${UNPACKDIR}/10-pacman.toml ${D}${libdir}/sota/conf.d/10-pacman.toml
 }

--- a/recipes-sota/config/aktualizr-disable-send-ip.bb
+++ b/recipes-sota/config/aktualizr-disable-send-ip.bb
@@ -11,9 +11,12 @@ SRC_URI = " \
             file://30-disable-send-ip.toml \
             "
 
+S = "${WORKDIR}/sources"
+UNPACKDIR = "${S}"
+
 do_install:append () {
     install -m 0700 -d ${D}${libdir}/sota/conf.d
-    install -m 0644 ${WORKDIR}/30-disable-send-ip.toml ${D}${libdir}/sota/conf.d/30-disable-send-ip.toml
+    install -m 0644 ${UNPACKDIR}/30-disable-send-ip.toml ${D}${libdir}/sota/conf.d/30-disable-send-ip.toml
 }
 
 FILES:${PN} = " \

--- a/recipes-sota/config/aktualizr-log-debug.bb
+++ b/recipes-sota/config/aktualizr-log-debug.bb
@@ -11,9 +11,12 @@ SRC_URI = " \
             file://05-log-debug.toml \
             "
 
+S = "${WORKDIR}/sources"
+UNPACKDIR = "${S}"
+
 do_install:append () {
     install -m 0700 -d ${D}${libdir}/sota/conf.d
-    install -m 0644 ${WORKDIR}/05-log-debug.toml ${D}${libdir}/sota/conf.d/05-log-debug.toml
+    install -m 0644 ${UNPACKDIR}/05-log-debug.toml ${D}${libdir}/sota/conf.d/05-log-debug.toml
 }
 
 FILES:${PN} = " \

--- a/recipes-sota/config/aktualizr-polling-interval.bb
+++ b/recipes-sota/config/aktualizr-polling-interval.bb
@@ -11,11 +11,14 @@ SRC_URI = " \
             file://60-polling-interval.toml \
             "
 
+S = "${WORKDIR}/sources"
+UNPACKDIR = "${S}"
+
 SOTA_POLLING_SEC ?= "30"
 
 do_install:append () {
     install -m 0700 -d ${D}${libdir}/sota/conf.d
-    install -m 0644 ${WORKDIR}/60-polling-interval.toml ${D}${libdir}/sota/conf.d/60-polling-interval.toml
+    install -m 0644 ${UNPACKDIR}/60-polling-interval.toml ${D}${libdir}/sota/conf.d/60-polling-interval.toml
 
     sed -i -e 's|@POLLING_SEC@|${SOTA_POLLING_SEC}|g' \
            ${D}${libdir}/sota/conf.d/60-polling-interval.toml

--- a/recipes-sota/config/aktualizr-virtualsec.bb
+++ b/recipes-sota/config/aktualizr-virtualsec.bb
@@ -12,10 +12,13 @@ SRC_URI = " \
             file://virtualsec.json \
             "
 
+S = "${WORKDIR}/sources"
+UNPACKDIR = "${S}"
+
 do_install:append () {
     install -m 0700 -d ${D}${libdir}/sota/conf.d
-    install -m 0644 ${WORKDIR}/30-virtualsec.toml ${D}${libdir}/sota/conf.d/30-virtualsec.toml
-    install -m 0644 ${WORKDIR}/virtualsec.json ${D}${libdir}/sota/virtualsec.json
+    install -m 0644 ${UNPACKDIR}/30-virtualsec.toml ${D}${libdir}/sota/conf.d/30-virtualsec.toml
+    install -m 0644 ${UNPACKDIR}/virtualsec.json ${D}${libdir}/sota/virtualsec.json
 }
 
 FILES:${PN} = " \

--- a/recipes-sota/ostree-initrd/ostree-initrd.bb
+++ b/recipes-sota/ostree-initrd/ostree-initrd.bb
@@ -4,7 +4,8 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda
 
 SRC_URI = "file://init.sh"
 
-S = "${WORKDIR}"
+S = "${WORKDIR}/sources"
+UNPACKDIR = "${S}"
 
 PV = "4"
 
@@ -12,7 +13,7 @@ do_install() {
 	install -dm 0755 ${D}/etc
 	touch ${D}/etc/initrd-release
 	install -dm 0755 ${D}/dev
-	install -m 0755 ${WORKDIR}/init.sh ${D}/init
+	install -m 0755 ${UNPACKDIR}/init.sh ${D}/init
 }
 
 inherit allarch

--- a/recipes-sota/ostree/ostree-booted_1.0.bb
+++ b/recipes-sota/ostree/ostree-booted_1.0.bb
@@ -6,10 +6,13 @@ SRC_URI = "file://touch-ostree"
 
 inherit allarch update-rc.d
 
+S = "${WORKDIR}/sources"
+UNPACKDIR = "${S}"
+
 INITSCRIPT_NAME = "touch-ostree"
 INITSCRIPT_PARAMS = "start 8 2 3 4 5 . stop 20 0 1 6 ."
 
 do_install() {
 	install -d ${D}${sysconfdir}/init.d
-	install -m 0755 ${WORKDIR}/touch-ostree ${D}${sysconfdir}/init.d/touch-ostree
+	install -m 0755 ${UNPACKDIR}/touch-ostree ${D}${sysconfdir}/init.d/touch-ostree
 }

--- a/recipes-support/slcand-start/slcand-start.bb
+++ b/recipes-support/slcand-start/slcand-start.bb
@@ -4,6 +4,9 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda
 
 inherit systemd
 
+S = "${WORKDIR}/sources"
+UNPACKDIR = "${S}"
+
 RDEPENDS:${PN} = "can-utils"
 
 SRC_URI = "file://slcand@.service"
@@ -12,7 +15,7 @@ SYSTEMD_SERVICE:${PN} = "slcand@.service"
 
 do_install() {
   install -d ${D}${systemd_unitdir}/system
-  install -m 0644 ${WORKDIR}/slcand@.service ${D}${systemd_unitdir}/system/slcand@.service
+  install -m 0644 ${UNPACKDIR}/slcand@.service ${D}${systemd_unitdir}/system/slcand@.service
 }
 
 FILES:${PN} = "${systemd_unitdir}/system/createtoken.service"

--- a/recipes-support/softhsm-testtoken/softhsm-testtoken.bb
+++ b/recipes-support/softhsm-testtoken/softhsm-testtoken.bb
@@ -4,6 +4,9 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda
 
 inherit systemd
 
+S = "${WORKDIR}/sources"
+UNPACKDIR = "${S}"
+
 RDEPENDS:${PN} = "softhsm libp11 opensc openssl-bin"
 DEPENDS:append = "${@bb.utils.contains('DISTRO_FEATURES', 'systemd', ' systemd', '', d)}"
 
@@ -15,9 +18,9 @@ SYSTEMD_SERVICE:${PN} = "createtoken.service"
 
 do_install() {
   install -d ${D}${systemd_unitdir}/system
-  install -m 0644 ${WORKDIR}/createtoken.service ${D}${systemd_unitdir}/system/createtoken.service
+  install -m 0644 ${UNPACKDIR}/createtoken.service ${D}${systemd_unitdir}/system/createtoken.service
   install -d ${D}${bindir}
-  install -m 0744 ${WORKDIR}/createtoken.sh ${D}${bindir}/createtoken.sh
+  install -m 0744 ${UNPACKDIR}/createtoken.sh ${D}${bindir}/createtoken.sh
 }
 
 FILES:${PN} = "${bindir}/createtoken.sh \

--- a/recipes-support/systemd-journald-persistent/systemd-journald-persistent.bb
+++ b/recipes-support/systemd-journald-persistent/systemd-journald-persistent.bb
@@ -9,12 +9,13 @@ PACKAGE_ARCH = "${MACHINE_ARCH}"
 SRC_URI:append = " file://10-persistent-journal.conf"
 PR = "r1"
 
-S = "${WORKDIR}"
+S = "${WORKDIR}/sources"
+UNPACKDIR = "${S}"
 
 FILES:${PN} = "${systemd_unitdir}/journald.conf.d/*"
 
 do_install() {
     install -d ${D}/${systemd_unitdir}/journald.conf.d
-    install -m 0644 ${WORKDIR}/10-persistent-journal.conf ${D}/${systemd_unitdir}/journald.conf.d
+    install -m 0644 ${UNPACKDIR}/10-persistent-journal.conf ${D}/${systemd_unitdir}/journald.conf.d
 }
 

--- a/recipes-test/demo-config/primary-config.bb
+++ b/recipes-test/demo-config/primary-config.bb
@@ -14,6 +14,9 @@ SRC_URI = "\
     ${@('file://' + d.getVar('SOTA_SECONDARY_CONFIG')) if d.getVar('SOTA_SECONDARY_CONFIG') else ''} \
     "
 
+S = "${WORKDIR}/sources"
+UNPACKDIR = "${S}"
+
 def get_secondary_addrs(d):
     import json
 
@@ -29,7 +32,7 @@ do_install () {
     if [ ! -n "${SOTA_SECONDARY_CONFIG}" ]; then
         bbwarn "SOTA_SECONDARY_CONFIG hasn't been specified in the local config, generate a default one"
 
-        IP_SECONDARY_CONFIG_FILE=${WORKDIR}/ip_secondary_config.json
+        IP_SECONDARY_CONFIG_FILE=${UNPACKDIR}/ip_secondary_config.json
         IP_SECONDARY_ADDRS='${@get_secondary_addrs(d)}'
     else
         bbwarn "SOTA_SECONDARY_CONFIG has been specified in the local config: ${SOTA_SECONDARY_CONFIG}"
@@ -59,7 +62,7 @@ do_install () {
 
     # install aktualizr config file (toml) that points to the secondary config file, so aktualizr is aware about it
     install -m 0700 -d ${D}${libdir}/sota/conf.d
-    install -m 0644 ${WORKDIR}/30-secondary-config.toml ${D}${libdir}/sota/conf.d
+    install -m 0644 ${UNPACKDIR}/30-secondary-config.toml ${D}${libdir}/sota/conf.d
     sed -i "s|@CFG_FILEPATH@|$SECONDARY_CONFIG_FILEPATH_ON_IMAGE|g" ${D}${libdir}/sota/conf.d/30-secondary-config.toml
 }
 

--- a/recipes-test/demo-config/secondary-config.bb
+++ b/recipes-test/demo-config/secondary-config.bb
@@ -30,20 +30,22 @@ SRC_URI = "\
     file://45-id-config.toml \
     "
 
+S = "${WORKDIR}/sources"
+UNPACKDIR = "${S}"
 
 do_install () {
     install -m 0700 -d ${D}${libdir}/sota/conf.d
 
-    install -m 0644 ${WORKDIR}/30-pacman-config.toml ${D}${libdir}/sota/conf.d/30-pacman-config.toml
+    install -m 0644 ${UNPACKDIR}/30-pacman-config.toml ${D}${libdir}/sota/conf.d/30-pacman-config.toml
     sed -i -e 's|@UPDATE_TYPE@|${UPDATE_TYPE}|g' ${D}${libdir}/sota/conf.d/30-pacman-config.toml
 
-    install -m 0644 ${WORKDIR}/35-network-config.toml ${D}${libdir}/sota/conf.d/35-network-config.toml
+    install -m 0644 ${UNPACKDIR}/35-network-config.toml ${D}${libdir}/sota/conf.d/35-network-config.toml
     sed -i -e 's|@PORT@|${SECONDARY_PORT}|g' \
            -e 's|@PRIMARY_IP@|${PRIMARY_IP}|g' \
            -e 's|@PRIMARY_PORT@|${PRIMARY_PORT}|g' \
            ${D}${libdir}/sota/conf.d/35-network-config.toml
 
-    install -m 0644 ${WORKDIR}/45-id-config.toml ${D}${libdir}/sota/conf.d/45-id-config.toml
+    install -m 0644 ${UNPACKDIR}/45-id-config.toml ${D}${libdir}/sota/conf.d/45-id-config.toml
     sed -i -e 's|@SERIAL@|${SECONDARY_SERIAL_ID}|g' \
            -e 's|@HWID@|${SECONDARY_HARDWARE_ID}|g' \
            ${D}${libdir}/sota/conf.d/45-id-config.toml

--- a/recipes-test/demo-network-config/network-config.inc
+++ b/recipes-test/demo-network-config/network-config.inc
@@ -10,7 +10,7 @@ SECONDARY_INTERFACE ?= "${@ 'eth0' if d.getVar('MACHINE') == 'raspberrypi3' else
 do_install:append() {
     bbnote "Network configuration type to be applied: ${CONF_TYPE}"
     install -d ${D}${libdir}/systemd/network
-    install -m 0644 ${WORKDIR}/26-${CONF_TYPE}-client.network ${D}${libdir}/systemd/network/
+    install -m 0644 ${UNPACKDIR}/26-${CONF_TYPE}-client.network ${D}${libdir}/systemd/network/
     sed -i -e 's|@ADDR@|${IP_ADDR}|g' \
            -e 's|@IFNAME@|${SECONDARY_INTERFACE}|g' \
            ${D}${libdir}/systemd/network/26-${CONF_TYPE}-client.network

--- a/recipes-test/demo-network-config/primary-network-config.bb
+++ b/recipes-test/demo-network-config/primary-network-config.bb
@@ -6,13 +6,16 @@ SRC_URI = "\
     file://27-dhcp-client-external.network \
     "
 
+S = "${WORKDIR}/sources"
+UNPACKDIR = "${S}"
+
 FILES:${PN} = "${libdir}/systemd/network"
 
 PR = "1"
 
 do_install() {
     install -d ${D}${libdir}/systemd/network
-    install -m 0644 ${WORKDIR}/27-dhcp-client-external.network ${D}${libdir}/systemd/network/
+    install -m 0644 ${UNPACKDIR}/27-dhcp-client-external.network ${D}${libdir}/systemd/network/
 }
 
 PRIMARY_IP ?= "192.168.254.1"

--- a/recipes-test/demo-network-config/secondary-network-config.bb
+++ b/recipes-test/demo-network-config/secondary-network-config.bb
@@ -10,13 +10,16 @@ SRC_URI = "\
     file://27-dhcp-client-external.network \
     "
 
+S = "${WORKDIR}/sources"
+UNPACKDIR = "${S}"
+
 FILES:${PN} = "${libdir}/systemd/network"
 
 PR = "1"
 
 do_install() {
     install -d ${D}${libdir}/systemd/network
-    install -m 0644 ${WORKDIR}/27-dhcp-client-external.network ${D}${libdir}/systemd/network/
+    install -m 0644 ${UNPACKDIR}/27-dhcp-client-external.network ${D}${libdir}/systemd/network/
 }
 
 SECONDARY_IP ?= "192.168.254.2"


### PR DESCRIPTION
On Yocto master (5.1 onwards)  it is no longer supported to use S = "${WORKDIR}". [1]

Following the 5.1 release notes [2], S should now be "${WORKDIR}/sources", and references for ${WORKDIR} in recipe tasks should either be ${UNPACKDIR} or ${S}.

[1] https://git.openembedded.org/openembedded-core/commit/?h=master&id=32cba1cc916ad530c5e6630a927e74ca6f06289b
[2] https://docs.yoctoproject.org/next/qmigration-guides/migration-5.1.html#s-workdir-no-longer-supported