### PR TITLE
image_types_ostree: refactor garagesign task

### DIFF
--- a/classes/image_types_ostree.bbclass
+++ b/classes/image_types_ostree.bbclass
@@ -201,7 +201,7 @@ IMAGE_CMD:garagesign () {
         fi
 
         rm -rf ${GARAGE_SIGN_REPO}
-        garage-sign init --repo tufrepo \
+        ${GARAGE_SIGN_TOOL} init --repo tufrepo \
                          --home-dir ${GARAGE_SIGN_REPO} \
                          --credentials ${SOTA_PACKED_CREDENTIALS}
 
@@ -236,9 +236,9 @@ IMAGE_CMD:garagesign () {
         fi
 
         for push_retries in $( seq ${GARAGE_PUSH_RETRIES} ); do
-            garage-sign targets pull --repo tufrepo \
+            ${GARAGE_SIGN_TOOL} targets pull --repo tufrepo \
                                      --home-dir ${GARAGE_SIGN_REPO}
-            garage-sign targets add --repo tufrepo \
+            ${GARAGE_SIGN_TOOL} targets add --repo tufrepo \
                                     --home-dir ${GARAGE_SIGN_REPO} \
                                     --name ${GARAGE_TARGET_NAME} \
                                     --format OSTREE \
@@ -253,12 +253,12 @@ IMAGE_CMD:garagesign () {
                     ${GARAGE_SIGN_REPO}/tufrepo/roles/unsigned/targets.json \
                     ${GARAGE_TARGET_NAME}-${target_version}
             fi
-            garage-sign targets sign --repo tufrepo \
+            ${GARAGE_SIGN_TOOL} targets sign --repo tufrepo \
                                      --home-dir ${GARAGE_SIGN_REPO} \
                                      ${target_expiry} \
                                      --key-name=targets
             errcode=0
-            garage-sign targets push --repo tufrepo \
+            ${GARAGE_SIGN_TOOL} targets push --repo tufrepo \
                                      --home-dir ${GARAGE_SIGN_REPO} || errcode=$?
             if [ "$errcode" -eq "0" ]; then
                 push_success=1

--- a/classes/sota.bbclass
+++ b/classes/sota.bbclass
@@ -35,6 +35,7 @@ OSTREE_OTA_REPO_CONFIG ?= ""
 
 INITRAMFS_IMAGE ?= "initramfs-ostree-image"
 
+GARAGE_SIGN_TOOL ?= "garage-sign"
 GARAGE_SIGN_REPO ?= "${DEPLOY_DIR_IMAGE}/garage_sign_repo"
 GARAGE_SIGN_KEYNAME ?= "garage-key"
 GARAGE_TARGET_NAME ?= "${OSTREE_BRANCHNAME}"


### PR DESCRIPTION
To enable usage of the Uptane's 'ota-tuf' repository for uptane-sign, we need to change this task. Since in more recent releases there, the tool name has changed from 'garage-sign' to 'uptane-sign'.

This way, we set the name of the tool used in a customizable variable, defaulting to 'garage-sign', and if anyone wants to use the latest version of this tool (given Aktualizr was also refactored), they just need to set this new variable with the tool name.