### PR TITLE
[WIP] Install full OSTree into the initramfs

### DIFF
--- a/recipes-core/images/initramfs-ostree-image.bb
+++ b/recipes-core/images/initramfs-ostree-image.bb
@@ -1,7 +1,11 @@
 # Netboot initramfs image.
 DESCRIPTION = "OSTree initramfs image"
 
-PACKAGE_INSTALL = "ostree-switchroot ostree-initrd busybox base-passwd ${ROOTFS_BOOTSTRAP_INSTALL}"
+# Install the full OSTree package into the initramfs.
+# This is needed to support using the non-static version of
+# ostree-prepare-root. The problem with ostree-prepare-root-static is that
+# expects to run as PID 1 and not as part of an initrd.
+PACKAGE_INSTALL = "ostree ostree-initrd busybox base-passwd ${ROOTFS_BOOTSTRAP_INSTALL}"
 
 SYSTEMD_DEFAULT_TARGET = "initrd.target"
 


### PR DESCRIPTION
Hi, I'm opening this PR mostly just to start a discussion about how ostree-prepare-root should be used.

I spent some time integrating meta-updater into my Yocto build and I ran into an issue where `ostree-prepare-root` (as called from the [init.sh](https://github.com/uptane/meta-updater/blob/master/recipes-sota/ostree-initrd/files/init.sh) script of the initrd) would throw an assert failure on this line: https://github.com/ostreedev/ostree/blob/main/src/switchroot/ostree-prepare-root-static.c#L166. It expects to be running as PID 1, which is not the case as the init.sh is our PID 1.

The top-level comment of ostree-prepare-static says:

```
[...]
 * This -static.c variant of ostree-prepare-root is designed for
 * the case where an initrd isn't used - instead the binary must be statically linked (and the
 * kernel must have mounted the rootfs itself) - then we set things up and exec the real init
 * directly.  
[...]
```

Since it seems that using an initrd is the intended way of using `meta-updater`, I added this to `ostree_%.bbappend` in my layer:

```
PACKAGECONFIG:remove = "static"
```

And I also changed [initramfs-ostree-image.bb](https://github.com/uptane/meta-updater/pull/106/files#diff-b318afdd4c7d676593489adeebce3263a93b087b1c5c616d39567563ed8be1cb) to install the full ostree (including shared libraries) into the initramfs.

This results in a change in size of the initramfs from 2MB to 10MB. I think it's possible to reduce it further by removing other PACKAGECONFIG options (like `curl`) for the `ostree` package intended for the initramfs. I haven't looked further into this yet.