### PR TITLE
Remove soup from PACKAGECONFIG only if ptest is not enabled

### DIFF
--- a/recipes-extended/ostree/ostree_%.bbappend
+++ b/recipes-extended/ostree/ostree_%.bbappend
@@ -7,4 +7,5 @@ SRC_URI += " \
 PACKAGECONFIG:append = " curl libarchive static builtin-grub2-mkconfig"
 PACKAGECONFIG:class-native:append = " curl"
 # gpgme is not required by us, and it brings GPLv3 dependencies
-PACKAGECONFIG:remove = "soup gpgme"
+PACKAGECONFIG:remove = "gpgme"
+PACKAGECONFIG:remove = "${@bb.utils.contains('DISTRO_FEATURES', 'ptest', '', 'soup', d)}"


### PR DESCRIPTION
I am working to enable ostree in my yocto build using meta-updater. 

I see a build issue related to ostree-ptest when ptest is enabled as part of the distro features. It seems like ostree-ptest has a dependency on ostree-trivial-httpd and it breaks on removing soup from PACKAGECONFIG. 

This change is to remove soup only if ptest is not enabled.

Build, boot up and ota update are successful with this change. 