### PR TITLE
[scarthgap] ostree: Remove soup from PACKAGECONFIG only if ptest is not enabled

### DIFF
--- a/recipes-extended/ostree/ostree_%.bbappend
+++ b/recipes-extended/ostree/ostree_%.bbappend
@@ -7,4 +7,5 @@ SRC_URI += " \
 PACKAGECONFIG:append = " curl libarchive static builtin-grub2-mkconfig"
 PACKAGECONFIG:class-native:append = " curl"
 # gpgme is not required by us, and it brings GPLv3 dependencies
-PACKAGECONFIG:remove = "soup gpgme"
+PACKAGECONFIG:remove = "gpgme"
+PACKAGECONFIG:remove = "${@bb.utils.contains('DISTRO_FEATURES', 'ptest', '', 'soup', d)}"


### PR DESCRIPTION
ostree-ptest has a dependency on ostree-trivial-httpd which gets compiled only if soup is enabled.

Signed-off-by: Roshan Sivakumar <quic_roshs@quicinc.com>
(cherry picked from commit 68865c1738badf86c6aaad87f22661e96ee5c4ac)