### PR TITLE
[master] image_type_ostree: fix reference of IMAGE_CMD_TAR variable

### DIFF
--- a/classes/image_types_ostree.bbclass
+++ b/classes/image_types_ostree.bbclass
@@ -37,7 +37,7 @@ do_image_ostree[cleandirs] = "${OSTREE_ROOTFS}"
 do_image_ostree[depends] = "coreutils-native:do_populate_sysroot virtual/kernel:do_deploy ${INITRAMFS_IMAGE}:do_image_complete"
 IMAGE_CMD:ostree () {
     # Copy required as we change permissions on some files.
-    ${IMAGE_CMD_TAR} -cf - -S -C ${IMAGE_ROOTFS} -p . | {IMAGE_CMD_TAR} -xf - -C ${OSTREE_ROOTFS}
+    ${IMAGE_CMD_TAR} -cf - -S -C ${IMAGE_ROOTFS} -p . | ${IMAGE_CMD_TAR} -xf - -C ${OSTREE_ROOTFS}
 
     # Just preserve var/local
     if [ -d var/local ]; then


### PR DESCRIPTION
This commit (https://github.com/uptane/meta-updater/commit/925dcfca94f0d5c2057eafc584d8f0838ac8faa9) started using IMAGE_CMD_TAR instead of hardcoding the tar command inside of IMG_CMD:ostree task. But the second instance of this variable is missing the '$' to reference it causing this build error:
```
10-29:22:18:15  | /workdir/oe/tmp/work/colibri_imx6-tdx-linux-gnueabi/torizon-core-docker/1.0-r0/temp/run.do_image_ostree.361095: 156: {IMAGE_CMD_TAR}: not found
10-29:22:18:15  | WARNING: exit code 127 from a shell command.
10-29:22:18:15  NOTE: recipe torizon-core-docker-1.0-r0: task do_image_ostree: Failed
10-29:22:18:15  ERROR: Task (/workdir/oe/build/conf/../../layers/meta-toradex-torizon/recipes-images/images/torizon-core-docker.bb:do_image_ostree) failed with exit code '1'
```