### PR TITLE
aktualizr: adjust tmpfile config

### DIFF
--- a/recipes-sota/aktualizr/files/aktualizr-tmpfiles.conf
+++ b/recipes-sota/aktualizr/files/aktualizr-tmpfiles.conf
@@ -1,1 +1,1 @@
-X /tmp/aktualizr-* 0700 root root -
+x /tmp/aktualizr-* 0700 root root -


### PR DESCRIPTION
"X" only excludes the directory from being cleaned-up. The contents of the directory can still be cleaned-up, resulting in curl error 58.

Change to "x" which recursively protects the directory and files.