### PR TITLE
patches: add the required Upstream-Status to this layer patches

### DIFF
--- a/recipes-extended/ostree/ostree/0001-ostree-fetcher-curl-set-a-timeout-for-an-overall-req.patch
+++ b/recipes-extended/ostree/ostree/0001-ostree-fetcher-curl-set-a-timeout-for-an-overall-req.patch
@@ -4,6 +4,8 @@ Date: Sat, 3 Jul 2021 20:37:08 -0300
 Subject: [PATCH] ostree-fetcher-curl: set a timeout for an overall request
  processing
 
+Upstream-Status: Inappropriate [embedded specific]
+
 Signed-off-by: Mike Sul <mike.sul@foundries.io>
 Signed-off-by: Ricardo Salveti <ricardo@foundries.io>
 Signed-off-by: Jose Quaresma <jose.quaresma@foundries.io>

--- a/recipes-sota/asn1c/files/skeletons_dir_fix.patch
+++ b/recipes-sota/asn1c/files/skeletons_dir_fix.patch
@@ -4,6 +4,8 @@ Date: Thu, 25 Jan 2018 09:49:41 +0100
 Subject: [PATCH] Patch the skeletons directory detection
 
 Detect `share/asn1c` from `bin/` if it exists
+
+Upstream-Status: Inappropriate [embedded specific]
 ---
  asn1c/asn1c.c | 9 ++++-----
  1 file changed, 4 insertions(+), 5 deletions(-)


### PR DESCRIPTION
Since now it is required for patches to have 'Upstream-Status', I've added 'Upstream-Status: Inappropriate [embedded specific]' to those patches, since they've been created for a long time and doesn't seem to have been upstreamed.