### PR TITLE
[scarthgap:backport] valgrind: add missing patch-status

### DIFF
--- a/recipes-devtools/valgrind/files/bug344802-unhandled-0xec510f1e.patch
+++ b/recipes-devtools/valgrind/files/bug344802-unhandled-0xec510f1e.patch
@@ -1,3 +1,7 @@
+Upstream-Status: Submitted [https://bugs.kde.org/show_bug.cgi?id=344802]
+
+Signed-off-by: Jose Quaresma <jose.quaresma@foundries.io>
+
 diff --git a/VEX/priv/guest_arm_defs.h b/VEX/priv/guest_arm_defs.h
 index 2ccbe4398..90312fbd4 100644
 --- a/VEX/priv/guest_arm_defs.h


### PR DESCRIPTION
(cherry picked from commit a6263085c28e3efc3848880494f85ead5471630e)