### PR TITLE
[scarthgap] ostree: Fix usage of ostree-prepare-root for initramfs

### DIFF
--- a/recipes-extended/ostree/ostree_%.bbappend
+++ b/recipes-extended/ostree/ostree_%.bbappend
@@ -4,7 +4,7 @@ SRC_URI += " \
             file://0001-ostree-fetcher-curl-set-a-timeout-for-an-overall-req.patch \
             "
 
-PACKAGECONFIG:append = " curl libarchive static builtin-grub2-mkconfig"
+PACKAGECONFIG:append = " curl libarchive builtin-grub2-mkconfig"
 PACKAGECONFIG:class-native:append = " curl"
 # gpgme is not required by us, and it brings GPLv3 dependencies
 PACKAGECONFIG:remove = "gpgme"


### PR DESCRIPTION
Since ostree v2023.5 and specifically commit
https://github.com/ostreedev/ostree/commit/d6799ecc243befcf714bcf54dbbd41da13a6e290

Building with static linking forces the usage of
ostree-prepare-root-static which is checking that it is executed as PID1.

This is incompatible with the usage of an initramfs.


(cherry picked from commit abd60ecf39c30b9e9ebb47565234e34f1eb6e5ef)