### PR TITLE
ostree-initrd: Move /run Mount Point to sysroot/run (Cherry-pick: 7ac47ea, 3de3b4f)

### DIFF
--- a/recipes-sota/ostree-initrd/files/init.sh
+++ b/recipes-sota/ostree-initrd/files/init.sh
@@ -65,7 +65,8 @@ mount "$ostree_sysroot" /sysroot || {
 ostree-prepare-root /sysroot
 
 mkdir -p /sysroot/run
-#Move /run(initramfs) to /sysroot/run(real-rootfs) 
+# Move /run(initramfs) to /sysroot/run(real-rootfs)
+# To avoid using a clean /run that is later mounted by systemd
 mount --move /run /sysroot/run
 
 log_info "Switching to rootfs"

--- a/recipes-sota/ostree-initrd/files/init.sh
+++ b/recipes-sota/ostree-initrd/files/init.sh
@@ -64,6 +64,10 @@ mount "$ostree_sysroot" /sysroot || {
 
 ostree-prepare-root /sysroot
 
+mkdir -p /sysroot/run
+#Move /run(initramfs) to /sysroot/run(real-rootfs) 
+mount --move /run /sysroot/run
+
 log_info "Switching to rootfs"
 # shellcheck disable=SC2093
 exec switch_root /sysroot /sbin/init


### PR DESCRIPTION
This PR cherry-picks two commits from master to scarthgap that both address
the relocation of the /run mount point from initramfs (/run) to the real root
filesystem (sysroot/run).