### PR TITLE
Add Feature fsverity and composefs

### DIFF
--- a/recipes-core/base-files/base-files_%.bbappend
+++ b/recipes-core/base-files/base-files_%.bbappend
@@ -1,0 +1,8 @@
+do_install:append () {
+    # Get rid of the /dev/root entry in fstab to avoid errors from
+    # systemd-remount-fs
+    if ${@bb.utils.contains('DISTRO_FEATURES', 'cfs', 'true', 'false', d)} ||
+       ${@bb.utils.contains('DISTRO_FEATURES', 'cfs-signed', 'true', 'false', d)}; then
+        sed -i -e '\#^ */dev/root#d' ${D}${sysconfdir}/fstab
+    fi
+}

--- a/recipes-core/images/initramfs-ostree-qcom-image.bb
+++ b/recipes-core/images/initramfs-ostree-qcom-image.bb
@@ -1,0 +1,40 @@
+DESCRIPTION = "Qcom OS OSTree initramfs image"
+
+PACKAGE_INSTALL = "initramfs-framework-base initramfs-module-udev \
+    initramfs-module-rootfs initramfs-module-debug initramfs-module-ostree \
+    ${VIRTUAL-RUNTIME_base-utils} base-passwd \
+"
+
+
+PACKAGE_INSTALL:append = "${@bb.utils.contains('DISTRO_FEATURES', 'cfs', ' initramfs-module-composefs', bb.utils.contains('DISTRO_FEATURES', 'cfs-signed', ' initramfs-module-composefs', '', d), d)}"
+
+
+SYSTEMD_DEFAULT_TARGET = "initrd.target"
+
+IMAGE_NAME_SUFFIX = ""
+# Do not pollute the initrd image with rootfs features
+IMAGE_FEATURES = ""
+
+export IMAGE_BASENAME = "initramfs-ostree-qcom-image"
+IMAGE_LINGUAS = ""
+
+LICENSE = "MIT"
+
+IMAGE_FSTYPES = "cpio.gz"
+IMAGE_FSTYPES:remove = "wic wic.gz wic.bmap wic.vmdk wic.vdi ext4 ext4.gz teziimg"
+
+IMAGE_CLASSES:remove = "image_repo_manifest license_image qemuboot"
+
+# avoid circular dependencies
+EXTRA_IMAGEDEPENDS = ""
+
+inherit core-image nopackages
+
+IMAGE_ROOTFS_SIZE = "8192"
+
+# Users will often ask for extra space in their rootfs by setting this
+# globally.  Since this is a initramfs, we don't want to make it bigger
+IMAGE_ROOTFS_EXTRA_SPACE = "0"
+IMAGE_OVERHEAD_FACTOR = "1.0"
+
+BAD_RECOMMENDATIONS += "busybox-syslog"

--- a/recipes-core/initramfs-framework/files/0001-Mount-run-with-tmpfs.patch
+++ b/recipes-core/initramfs-framework/files/0001-Mount-run-with-tmpfs.patch
@@ -1,0 +1,55 @@
+From 20d74a29c1c9050880f0456b2c3a0242c9c8ab70 Mon Sep 17 00:00:00 2001
+From: Sasi Kumar Maddineni <quic_sasikuma@quicinc.com>
+Date: Thu, 5 Jun 2025 15:02:40 +0530
+Subject: [PATCH] Mount /run with tmpfs
+
+Upstream-Status: Pending
+
+Signed-off-by: Ricardo Salveti <ricardo@foundries.io>
+Git-Commit: 0c3b2340811774b495920c397c5603448446d160
+Git-repo: https://github.com/foundriesio/meta-lmp
+
+[Sasi Kumar Maddineni <quic_sasikuma@quicinc.com>: Resolved merge conflicts]
+Signed-off-by: Sasi Kumar Maddineni <quic_sasikuma@quicinc.com>
+---
+ finish | 3 ++-
+ init   | 4 +++-
+ 2 files changed, 5 insertions(+), 2 deletions(-)
+
+diff --git a/finish b/finish
+index ac0de9f..ed8298d 100755
+--- a/finish
++++ b/finish
+@@ -35,10 +35,11 @@ finish_run() {
+ 			mount -n --move "$dir" "${ROOTFS_DIR}/media/${dir##*/}"
+ 		done
+ 
+-		debug "Moving /dev, /proc and /sys onto rootfs..."
++		debug "Moving /dev, /proc, /sys and /run onto rootfs..."
+ 		mount --move /dev $ROOTFS_DIR/dev
+ 		mount --move /proc $ROOTFS_DIR/proc
+ 		mount --move /sys $ROOTFS_DIR/sys
++		mount --move /run $ROOTFS_DIR/run
+ 
+ 		cd $ROOTFS_DIR
+ 		exec switch_root -c /dev/console $ROOTFS_DIR ${bootparam_init:-/sbin/init}
+diff --git a/init b/init
+index 20c0455..495d157 100755
+--- a/init
++++ b/init
+@@ -78,9 +78,11 @@ EFI_DIR=/sys/firmware/efi  # place to store device firmware information
+ touch /etc/fstab
+ 
+ # initialize /proc, /sys, /run/lock and /var/lock
+-mkdir -p /proc /sys /run/lock /var/lock
++mkdir -p /proc /sys /run
+ mount -t proc proc /proc
+ mount -t sysfs sysfs /sys
++mount -t tmpfs tmpfs /run
++mkdir -p /run/lock /var/lock
+ 
+ if [ -d $EFI_DIR ];then
+ 	mount -t efivarfs none /sys/firmware/efi/efivars
+-- 
+2.34.1
+

--- a/recipes-core/initramfs-framework/files/composefs
+++ b/recipes-core/initramfs-framework/files/composefs
@@ -1,0 +1,249 @@
+#!/bin/sh
+# Copyright (C) 2023 Toradex AG.
+# Licensed on MIT
+
+# Enable additions to allow upgrades from legacy to composefs-based storage (OSTree).
+CFS_UPGRADE_ENABLE="${CFS_UPGRADE_ENABLE:-@@CFS_UPGRADE_ENABLE@@}"
+
+# Force enabling fsverity (mostly for debugging purposes).
+CFS_ALWAYS_ENABLE="${CFS_ALWAYS_ENABLE:-0}"
+
+SYSROOT_DIR="/sysroot"
+COMPOSEFS_NAME=".ostree.cfs"
+PREPARE_ROOT_CFG="/usr/lib/ostree/prepare-root.conf"
+
+composefs_enabled() {
+	return 0
+}
+
+composefs_warn() {
+	msg "## WARNING: $*"
+}
+
+composefs_enable_fsverity_fs() {
+	root_dev=$(mount | sed -ne "\#${ROOTFS_DIR}# {s# *\(/dev/[^ ]*\) .*#\1#p}")
+	if [ ! -b "${root_dev}" ]; then
+		composefs_warn "Could not determine root device!"
+		return 1
+	fi
+
+	if tune2fs -l "${root_dev}" 2>/dev/null | \
+	   grep -q -i 'filesystem features:.*\bverity\b'; then
+		info 'Feature "verity" is already enabled on the filesystem.'
+	else
+		if tune2fs -O verity "${root_dev}"; then
+			msg 'Enabling "verity" feature on the filesystem succeeded.'
+		else
+			composefs_warn 'Enabling "verity" feature on the filesystem FAILED.'
+			return 1
+		fi
+	fi
+
+	return 0
+}
+
+# $1: number of currently processed items
+# $2: total number of items to process
+# $3: (optional) when set to "1", a newline is added at the end
+composefs_progress() {
+	bar_cur="${1}"
+	bar_tot="${2}"
+	bar_end="${3}"
+
+	bar_curtm="$(date '+%s')"
+	bar_updtm="${bar_updtm:-0}"
+	bar_difftm="$((bar_curtm - bar_updtm))"
+	if [ "${bar_difftm}" -lt 1 ] && [ "${bar_end}" != "1" ]; then
+		# Update only once every second
+		return
+	fi
+	bar_updtm="$(date '+%s')"
+
+	bar_len="50"
+	bar_done="$((bar_len * bar_cur / bar_tot))"
+	bar_todo="$((bar_len - bar_done))"
+	bar_str1="$(printf "%*s" "${bar_done}" '' | tr ' ' '=')"
+	bar_str2="$(printf "%*s" "${bar_todo}" '' | tr ' ' '.')"
+	bar_str3="$(printf "%d" "${bar_cur}")"
+	bar_str4="$(printf "%d" "${bar_tot}")"
+
+	bar_str="$(printf "\rProgress: [%s%s] (%5s/%5s)" "${bar_str1}" "${bar_str2}" "${bar_str3}" "${bar_str4}")"
+
+	msg -n "${bar_str}"
+	[ "${bar_end}" = "1" ] && msg ""
+}
+
+# We could replace this whole function by:
+#
+# $ ostree admin post-copy --sysroot="${SYSROOT_DIR}"
+#
+# However this would bring in the dependency of ostree to the ramdisk
+# which doesn't look like a good idea. Instead, here we depend only on
+# "findutils" and "fsverity-utils".
+#
+composefs_enable_fsverity_files() {
+	nfiles="$(find "${SYSROOT_DIR}/ostree/repo/objects" -type f | wc -l)"
+	count="0"
+	tmpf="$(mktemp)"
+
+	# Enable verity on all repository files.
+	find "${SYSROOT_DIR}/ostree/repo/objects" -type f | while read -r fname; do
+		composefs_progress "${count}" "${nfiles}"
+		{ fsverity enable "${fname}" || fsverity measure "${fname}"; } >/dev/null 2>/dev/null
+		# shellcheck disable=SC2181
+		if [ "$?" -ne 0 ]; then
+			echo "ERROR: Could not enable fsverity on '${fname}'." >>"${tmpf}"
+		fi
+		count=$((count + 1))
+	done
+
+	composefs_progress "${nfiles}" "${nfiles}" "1"
+	msg ""
+
+	# And also on the composefs file of every deployment.
+	for fname in $(ls -1 "${SYSROOT_DIR}/ostree/deploy"/*/deploy/*/"${COMPOSEFS_NAME}" 2>/dev/null); do
+		{ fsverity enable "${fname}" || fsverity measure "${fname}"; } >/dev/null 2>/dev/null
+		# shellcheck disable=SC2181
+		if [ "$?" -ne 0 ]; then
+			echo "ERROR: Could not enable fsverity on '${fname}'." >>"${tmpf}"
+		fi
+	done
+
+	nerrors=$(grep -c 'ERROR:' "${tmpf}")
+	if [ "${nerrors}" -ne 0 ]; then
+		msg "Could not enable fsverity on ${nerrors} files (out of ${nfiles})."
+		return 1
+	fi
+
+	return 0
+}
+
+composefs_ensure_fsverity() {
+	# Do we need fsverity?
+	if [ ! -f "${PREPARE_ROOT_CFG}" ]; then
+		info "No ${PREPARE_ROOT_CFG} found - assuming fsverity is not needed"
+		return 0
+	fi
+
+	# Allow setting composefs.enabled config via kernel cmdline;
+	# "cfs.enabled" could be set to false|true|signed or any other value accepted
+	# by "ostree-prepare-root".
+	if [ -n "${bootparam_cfs_enabled}" ]; then
+		info "Overriding composefs.enabled: setting to ${bootparam_cfs_enabled}"
+		sed -i -e "/^\[composefs\]/,/^\[.*\]/ {s/^enabled[[:space:]]*=.*\$/enabled = ${bootparam_cfs_enabled}/}" "${PREPARE_ROOT_CFG}"
+	fi
+
+	# Check configuration key composefs.enabled; this could be set to no|maybe|yes|signed.
+	enabled="$(sed -n -e '/^\[composefs\]/,/^\[.*\]/ {s/^enabled[[:space:]]*=[[:space:]]*\([^[:space:]]*\)/\1/p}' "${PREPARE_ROOT_CFG}")"
+	enabled="${enabled:-no}"
+	debug "composefs.enabled=${enabled}"
+
+	if [ "${enabled}" = "no" ]; then
+		info "composefs is not enabled in ${PREPARE_ROOT_CFG}"
+		return 0
+	fi
+
+	# Enable fsverity at the filesystem level.
+	if ! composefs_enable_fsverity_fs; then
+		info "Could not enable fsverity on the fs - avoid enabling it on individual files"
+		return 1
+	fi
+
+	if [ -z "${bootparam_ostree}" ]; then
+		info "Parameter ostree= not passed in kernel cmdline"
+		return 1
+	fi
+
+	# Determine deployment being booted from kernel cmdline:
+	deployment="$(realpath -e "${SYSROOT_DIR}${bootparam_ostree}" 2>/dev/null)"
+	if [ -z "${deployment}" ]; then
+		info "Could not determine current deployment (ostree=${bootparam_ostree})"
+		return 1
+	fi
+
+	cfsfile="${deployment}/${COMPOSEFS_NAME}"
+	lockfile="${SYSROOT_DIR}/ostree/repo/enable-verity.lock"
+
+	if [ ! -f "${cfsfile}" ]; then
+		info "File '${cfsfile}' does not exist"
+	fi
+
+	# Handle the case where fsverity is partially enabled on the repository; this would normally
+	# happen when transitioning from legacy to composefs-backed installations.
+	enable_verity_on_upgrade="0"
+	if [ "${CFS_UPGRADE_ENABLE}" = "1" ]; then
+		# Use the /usr/etc/os-release file to figure out if fsverity is not enabled in some
+		# of the deployments.
+		osrfiles=$(ls -1 ${SYSROOT_DIR}/ostree/deploy/torizon/deploy/*/usr/etc/os-release 2>/dev/null)
+		for fn in ${osrfiles}; do
+			if ! fsverity measure "${fn}" >/dev/null 2>/dev/null; then
+				enable_verity_on_upgrade="1"
+				break
+			fi
+		done
+	fi
+
+	# We want to enable fsverity in any of the following cases:
+	#
+	# - If the lockfile exists; fsverity enabling operation may have been interrupted.
+	# - If fsverity is not enabled on the .cfs file; this would be the case after an OS
+	#   installation with e.g. Toradex Easy Installer (or any installer that unpacks a
+	#   tarball with the rootfs).
+	# - If we are upgrading from a legacy system and composefs is not enabled on some
+	#   files (this is optional and enabled by setting CFS_UPGRADE_ENABLE="1").
+	#
+	if [ -f "${lockfile}" ]; then
+		info "Lockfile exists - continue fsverity enabling"
+	elif [ -f "${cfsfile}" ] && ! fsverity measure "${cfsfile}" >/dev/null 2>/dev/null; then
+		info "File '${cfsfile}' does not have fsverity info - start fsverity enabling"
+	elif [ "${enable_verity_on_upgrade}" = "1" ]; then
+		info "Some deployment does not have fsverity info - start fsverity enabling"
+	elif [ "${CFS_ALWAYS_ENABLE}" = "1" ]; then
+		info "CFS_ALWAYS_ENABLE is set - start fsverity enabling"
+	else
+		info "Enabling fsverity on repository is not needed"
+		return 0
+	fi
+
+	# Stretch protected by a lockfile.
+	# ---
+	touch "${lockfile}" || return 1
+
+	msg ""
+	msg "Enabling fsverity on the ostree repository - this may take a few minutes."
+	msg ""
+
+	t0="$(date '+%s')"
+	composefs_enable_fsverity_files
+	composefs_enable_status="$?"
+	t1="$(date '+%s')"
+
+	# ---
+	rm "${lockfile}"
+
+	msg "Enabling fsverity took $((t1 - t0)) seconds."
+
+	if [ "${composefs_enable_status}" -ne 0 ]; then
+		# TODO: Consider rebooting or forcing a rollback.
+		# TODO: Consider copying the file holding the errors somewhere.
+		composefs_warn "Enabling fsverity failed - system may not boot."
+		return 1
+	fi
+
+	return 0
+}
+
+composefs_run() {
+	info "Running composefs script..."
+
+	if [ -d "${ROOTFS_DIR}" ]; then
+		# When built with composefs support ostree-prepare-root will
+		# look for objects under /sysroot which is actually the rootfs
+		# directory in the ramdisk.
+		ln -sf "${ROOTFS_DIR}" "${SYSROOT_DIR}"
+		composefs_ensure_fsverity
+	else
+		info "No rootfs has been set"
+		return 1
+	fi
+}

--- a/recipes-core/initramfs-framework/files/ostree
+++ b/recipes-core/initramfs-framework/files/ostree
@@ -1,0 +1,16 @@
+#!/bin/sh
+# Copyright (C) 2018 Open Source Foundries Ltd.
+# Licensed on MIT
+
+ostree_enabled() {
+	return 0
+}
+
+ostree_run() {
+	if [ -n "$ROOTFS_DIR" ]; then
+		info "Preparing OSTree root at '$ROOTFS_DIR'..."
+		/usr/lib/ostree/ostree-prepare-root $ROOTFS_DIR
+	else
+		debug "No rootfs has been set"
+	fi
+}

--- a/recipes-core/initramfs-framework/initramfs-framework_1.0.bbappend
+++ b/recipes-core/initramfs-framework/initramfs-framework_1.0.bbappend
@@ -1,0 +1,88 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
+SRC_URI += "\
+    file://ostree \
+    file://0001-Mount-run-with-tmpfs.patch \
+"
+
+SRC_URI:append = "\
+    ${@bb.utils.contains('DISTRO_FEATURES', 'cfs', ' file://composefs', '', d)} \
+"
+
+PACKAGES:append = " \
+    initramfs-module-ostree \
+"
+
+PACKAGES:append = "\
+    ${@bb.utils.contains('DISTRO_FEATURES', 'cfs', ' initramfs-module-composefs', '', d)} \
+"
+
+
+
+SUMMARY:initramfs-module-ostree = "initramfs support for ostree based filesystems"
+RDEPENDS:initramfs-module-ostree = "${PN}-base ostree-switchroot"
+FILES:initramfs-module-ostree = "/init.d/95-ostree"
+
+SUMMARY:initramfs-module-composefs = "initramfs support for booting composefs images"
+RDEPENDS:initramfs-module-composefs = "${PN}-base"
+
+RDEPENDS:initramfs-module-composefs:append = "${@bb.utils.contains('DISTRO_FEATURES', 'cfs-signed', ' fsverity-utils e2fsprogs-tune2fs', '', d)}"
+
+FILES:initramfs-module-composefs = "\
+    /init.d/94-composefs \
+    ${nonarch_libdir}/ostree/prepare-root.conf \
+"
+FILES:initramfs-module-composefs:append = "${@bb.utils.contains('DISTRO_FEATURES', 'cfs-signed', ' ${sysconfdir}/ostree/initramfs-root-binding.key', '', d)}"
+
+do_install:append() {
+    install -m 0755 ${WORKDIR}/ostree ${D}/init.d/95-ostree
+}
+
+CFS_UPGRADE_ENABLE ?= "0"
+
+require recipes-extended/ostree/gen-cfs-keys.inc
+
+generate_cfs_keys[lockfiles] += "${DEPLOY_DIR_IMAGE}/cfskeys.lock"
+generate_cfs_keys() {
+    gen_cfs_keys
+}
+
+CFS_INSTALL_PREFUNCS_COND ?= " generate_cfs_keys"
+CFS_INSTALL_PREFUNCS ?= \
+     "${@d.getVar('CFS_INSTALL_PREFUNCS_COND') if 'cfs-signed' in d.getVar('DISTRO_FEATURES').split() else ''}"
+CFS_INSTALL_DEPENDS_COND ?= "\
+     coreutils-native:do_populate_sysroot \
+     openssl-native:do_populate_sysroot \
+ "
+CFS_INSTALL_DEPENDS ?= \
+     "${@d.getVar('CFS_INSTALL_DEPENDS_COND') if 'cfs-signed' in d.getVar('DISTRO_FEATURES').split() else ''}"
+
+CFS_INSTALL_FILE_CHECKSUMS ?= "${@cfs_get_key_file_checksums(d)}"
+
+do_install[prefuncs] += "${CFS_INSTALL_PREFUNCS}"
+do_install[depends] += "${CFS_INSTALL_DEPENDS}"
+do_install[file-checksums] += "${CFS_INSTALL_FILE_CHECKSUMS}"
+ 
+
+require recipes-extended/ostree/ostree-prepare-root.inc
+do_install:append() {
+
+    if echo "${DISTRO_FEATURES}" | grep -q -e " cfs"; then
+        # Bundled into initramfs-module-composefs package:
+        install -m 0755 ${WORKDIR}/composefs ${D}/init.d/94-composefs
+        sed -i -e 's/@@CFS_UPGRADE_ENABLE@@/${CFS_UPGRADE_ENABLE}/g' ${D}/init.d/94-composefs
+
+        install -d ${D}${nonarch_libdir}/ostree/
+        install -m 0644 /dev/null ${D}${nonarch_libdir}/ostree/prepare-root.conf
+        write_prepare_root_config ${D}${nonarch_libdir}/ostree/prepare-root.conf
+        if echo "${DISTRO_FEATURES}" | grep -q -e " cfs-signed"; then
+            # Bundled into initramfs-module-composefs package:
+            install -d ${D}${sysconfdir}/ostree/
+            install -m 0644 ${CFS_SIGN_KEYDIR}/${CFS_SIGN_KEYNAME}.pub \
+    	            ${D}${sysconfdir}/ostree/initramfs-root-binding.key
+        fi
+    fi
+
+}
+
+

--- a/recipes-extended/ostree/gen-cfs-keys.inc
+++ b/recipes-extended/ostree/gen-cfs-keys.inc
@@ -1,0 +1,55 @@
+gen_cfs_keys0() {
+    local keydir="${1}"
+    local keyname="${2}"
+
+    local pubkey="${keydir}/${keyname}.pub"
+    local seckey="${keydir}/${keyname}.sec"
+
+    mkdir -p "${keydir}"
+
+    local pem="$(openssl genpkey -algorithm ed25519 -outform PEM)"
+    local pub="$(printf "%s" "${pem}" | openssl pkey -outform DER -pubout | tail -c 32 | base64)"
+    local seed="$(printf "%s" "${pem}" | openssl pkey -outform DER | tail -c 32 | base64)"
+
+    # Save secret key (concatenate seed and pub key); see libtest.sh in the ostree code base:
+    (printf "%s" "${seed}" | base64 -d && \
+     printf "%s" "${pub}"  | base64 -d) | base64 > "${seckey}"
+
+    # Save public key:
+    printf "%s" "${pub}" > "${pubkey}"
+}
+
+gen_cfs_keys() {
+    if [ -z "${CFS_SIGN_KEYDIR}" ] || [ -z "${CFS_SIGN_KEYNAME}" ] || [ -z "${CFS_GENERATE_KEYS}" ]; then
+        bbfatal "Secure boot signing not correctly set up."
+    fi
+
+    local pubkey="${CFS_SIGN_KEYDIR}/${CFS_SIGN_KEYNAME}.pub"
+    local seckey="${CFS_SIGN_KEYDIR}/${CFS_SIGN_KEYNAME}.sec"
+
+    if [ "${CFS_GENERATE_KEYS}" = "1" ]; then
+        if [ -f "${pubkey}" ] && [ -f "${seckey}" ]; then
+	    bbnote "Key pair \"${CFS_SIGN_KEYNAME}\" already exists; skipping generation."
+	else
+	    # Generate the key pair:
+	    bbnote "Generating key pair \"${CFS_SIGN_KEYNAME}\" (.pub, .sec)."
+	    gen_cfs_keys0 "${CFS_SIGN_KEYDIR}" "${CFS_SIGN_KEYNAME}"
+	fi
+    fi
+
+    if [ ! -f "${seckey}" ]; then
+        bbfatal "Could not find key file \"${seckey}\"."
+    fi
+}
+
+def cfs_get_key_file_checksums(d):
+    if "cfs-signed" not in d.getVar("OVERRIDES").split(":"):
+        return ""
+    seckey = os.path.join(d.getVar("CFS_SIGN_KEYDIR"),
+                          d.getVar("CFS_SIGN_KEYNAME") + ".sec")
+    pubkey = os.path.join(d.getVar("CFS_SIGN_KEYDIR"),
+                          d.getVar("CFS_SIGN_KEYNAME") + ".pub")
+    return " ".join([
+        seckey + (":True" if os.path.exists(seckey) else ":False"),
+        pubkey + (":True" if os.path.exists(pubkey) else ":False")
+    ])

--- a/recipes-extended/ostree/ostree-prepare-root.inc
+++ b/recipes-extended/ostree/ostree-prepare-root.inc
@@ -1,0 +1,24 @@
+# Configuration that goes into prepare-root.conf (see ostree-prepare-root manual):
+#
+# - PREP_ROOT_ETC_TRANSIENT: whether /etc is transient ("true" or "false")
+# - PREP_ROOT_CFS_ENABLED: enabling of composefs ("yes", "no", "maybe" or "signed")
+#
+PREP_ROOT_ETC_TRANSIENT ?= "true"
+PREP_ROOT_CFS_ENABLED_DEFAULT = "no"
+PREP_ROOT_CFS_ENABLED_DEFAULT = "${@bb.utils.contains('DISTRO_FEATURES', 'cfs-signed', 'signed', bb.utils.contains('DISTRO_FEATURES', 'cfs', 'yes', 'no', d), d)}"
+PREP_ROOT_CFS_ENABLED ?= "${PREP_ROOT_CFS_ENABLED_DEFAULT}"
+
+write_prepare_root_config() {
+    local outfile="${1?Output file name required}"
+
+    cat >${outfile} <<EOF
+[etc]
+transient = ${PREP_ROOT_ETC_TRANSIENT}
+
+[composefs]
+enabled = ${PREP_ROOT_CFS_ENABLED}
+
+[sysroot]
+readonly = false
+EOF
+}

--- a/recipes-extended/ostree/ostree/0001-mount-Allow-building-when-macro-MOUNT_ATTR_IDMAP-is-.patch
+++ b/recipes-extended/ostree/ostree/0001-mount-Allow-building-when-macro-MOUNT_ATTR_IDMAP-is-.patch
@@ -1,0 +1,70 @@
+From e865b52379b48c5ffb2577ea06d78e3f219670b7 Mon Sep 17 00:00:00 2001
+From: Sasi Kumar Maddineni <quic_sasikuma@quicinc.com>
+Date: Fri, 6 Jun 2025 09:09:22 +0530
+Subject: [PATCH 1/2] mount: Allow building when macro MOUNT_ATTR_IDMAP is not
+ available
+
+This is to allow building the software on machines not having the
+MOUNT_ATTR_IDMAP macro in header "linux/mount.h". When that macro is not
+available, the dependency on struct mount_attr is also eliminated (which
+is good since both the macro and the struct were added to the kernel
+uapi virtually at the same time).
+
+With the changes in this commit, errors would be thrown at runtime when
+mounting the erofs image, but only if the idmap feature is used; this
+resembles the behavior when the "new mount API" is not detected.
+
+Upstream-Status: Accepted
+[https://github.com/containers/composefs/pull/253]
+
+Signed-off-by: Rogerio Guerra Borin <rogerio.borin@toradex.com>
+Git-Commit: f163eba6ce8826007b3a1c10eb47fa41f490e217
+Git-repo: https://github.com/composefs/composefs.git
+
+[Sasi Kumar Maddineni <quic_sasikuma@quicinc.com>: Resolved merge conflicts]
+Signed-off-by: Sasi Kumar Maddineni <quic_sasikuma@quicinc.com>
+---
+ composefs/libcomposefs/lcfs-mount.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/composefs/libcomposefs/lcfs-mount.c b/composefs/libcomposefs/lcfs-mount.c
+index 3dd518b..4d1a729 100644
+--- a/composefs/libcomposefs/lcfs-mount.c
++++ b/composefs/libcomposefs/lcfs-mount.c
+@@ -108,6 +108,7 @@ static int syscall_move_mount(int from_dfd, const char *from_pathname, int to_df
+ #endif
+ }
+ 
++#ifdef HAVE_MOUNT_ATTR_IDMAP
+ static int syscall_mount_setattr(int dfd, const char *path, unsigned int flags,
+ 				 struct mount_attr *attr, size_t usize)
+ {
+@@ -122,6 +123,7 @@ static int syscall_mount_setattr(int dfd, const char *path, unsigned int flags,
+ 	return -1;
+ #endif
+ }
++#endif
+ 
+ #define MAX_DIGEST_SIZE 64
+ 
+@@ -520,6 +522,7 @@ static errint_t lcfs_mount_erofs(const char *source, const char *target,
+ 		return -errno;
+ 
+ 	if (use_idmap) {
++#ifdef HAVE_MOUNT_ATTR_IDMAP
+ 		struct mount_attr attr = {
+ 			.attr_set = MOUNT_ATTR_IDMAP,
+ 			.userns_fd = state->options->idmap_fd,
+@@ -529,6 +532,9 @@ static errint_t lcfs_mount_erofs(const char *source, const char *target,
+ 					    sizeof(struct mount_attr));
+ 		if (res < 0)
+ 			return -errno;
++#else
++                return -ENOTSUP;
++#endif
+ 	}
+ 
+ 	res = syscall_move_mount(fd_mnt, "", AT_FDCWD, target,
+-- 
+2.34.1
+

--- a/recipes-extended/ostree/ostree/0002-mount-Allow-building-when-macro-LOOP_CONFIGURE-is-no.patch
+++ b/recipes-extended/ostree/ostree/0002-mount-Allow-building-when-macro-LOOP_CONFIGURE-is-no.patch
@@ -1,0 +1,53 @@
+From e92bbaed760686cb1e4aa56f7fa1f2ff7ff18bcb Mon Sep 17 00:00:00 2001
+From: Sasi Kumar Maddineni <quic_sasikuma@quicinc.com>
+Date: Fri, 6 Jun 2025 09:20:39 +0530
+Subject: [PATCH 2/2] mount: Allow building when macro LOOP_CONFIGURE is not
+ available
+
+This is to allow building the software on machines not having the macro
+LOOP_CONFIGURE or the struct loop_config in header "linux/loop.h" (both
+of which added to the kernel uapi at the same time); the code snippet
+providing them was taken from package util-linux, source file
+"include/loopdev.h".
+
+Upstream-Status: Accepted
+[https://github.com/containers/composefs/pull/253]
+
+Signed-off-by: Rogerio Guerra Borin <rogerio.borin@toradex.com>
+Git-Commit: 384f3068a878ef3c4e29d05a05da3899e111d709
+Git-repo: https://github.com/composefs/composefs.git
+
+[Sasi Kumar Maddineni <quic_sasikuma@quicinc.com>: Resolved merge conflicts]
+Signed-off-by: Sasi Kumar Maddineni <quic_sasikuma@quicinc.com>
+---
+ composefs/libcomposefs/lcfs-mount.c | 14 ++++++++++++++
+ 1 file changed, 14 insertions(+)
+
+diff --git a/composefs/libcomposefs/lcfs-mount.c b/composefs/libcomposefs/lcfs-mount.c
+index 4d1a729..c0ce54c 100644
+--- a/composefs/libcomposefs/lcfs-mount.c
++++ b/composefs/libcomposefs/lcfs-mount.c
+@@ -49,6 +49,20 @@
+ #include "lcfs-utils.h"
+ #include "lcfs-internal.h"
+ 
++#ifndef LOOP_CONFIGURE
++/* Snippet from util-linux/include/loopdev.h
++ *
++ * Since Linux v5.8-rc1 (commit 3448914e8cc550ba792d4ccc74471d1ca4293aae)
++ */
++#define LOOP_CONFIGURE 0x4C0A
++struct loop_config {
++       uint32_t fd;
++       uint32_t block_size;
++       struct loop_info64 info;
++       uint64_t __reserved[8];
++};
++#endif
++
+ static int syscall_fsopen(const char *fs_name, unsigned int flags)
+ {
+ #if defined __NR_fsopen
+-- 
+2.34.1
+

--- a/recipes-extended/ostree/ostree/ostree-repo-config.service
+++ b/recipes-extended/ostree/ostree/ostree-repo-config.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Update static OSTree repository configuration
+Before=aktualizr.service
+
+[Service]
+Type=oneshot
+WorkingDirectory=/sysroot
+ExecStart=/usr/sbin/ostree-repo-config.sh
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/recipes-extended/ostree/ostree/ostree-repo-config.sh
+++ b/recipes-extended/ostree/ostree/ostree-repo-config.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+CFG_COMPOSEFS=${OSTREE_REPO_CFG_COMPOSEFS:-@@OSTREE_REPO_CFG_COMPOSEFS@@}
+CFG_FSVERITY=${OSTREE_REPO_CFG_FSVERITY:-@@OSTREE_REPO_CFG_FSVERITY@@}
+
+ostree_cfg_set() {
+    local key=${1?key required}
+    local val=${2}
+    local cur=$(ostree config get "${key}" 2>/dev/null)
+
+    if [ "$val" != "$cur" ]; then
+	# Avoid writing to the file if the value is already set as expected.
+	if [ -n "${val}" ]; then
+	    echo "setting ostree config '${key}' to '${val}'"
+	    ostree config set "${key}" "${val}"
+	else
+	    echo "clearing ostree config '${key}'"
+	    ostree config unset "${key}"
+	fi
+    else
+	echo "ostree config '${key}' is already set to '${val}'"
+    fi
+}
+
+ostree_cfg_set "ex-integrity.composefs" "${CFG_COMPOSEFS}"
+ostree_cfg_set "ex-integrity.fsverity" "${CFG_FSVERITY}"

--- a/recipes-extended/ostree/ostree_%.bbappend
+++ b/recipes-extended/ostree/ostree_%.bbappend
@@ -1,7 +1,71 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
+SRC_URI += " \
+            file://0001-mount-Allow-building-when-macro-MOUNT_ATTR_IDMAP-is-.patch \
+            file://0002-mount-Allow-building-when-macro-LOOP_CONFIGURE-is-no.patch \
+            file://ostree-repo-config.sh \
+            file://ostree-repo-config.service \
+            "
+
 PACKAGECONFIG:append = " curl libarchive builtin-grub2-mkconfig"
 PACKAGECONFIG:class-native:append = " curl"
 # gpgme is not required by us, and it brings GPLv3 dependencies
 PACKAGECONFIG:remove = "gpgme"
 PACKAGECONFIG:remove = "${@bb.utils.contains('DISTRO_FEATURES', 'ptest', '', 'soup', d)}"
+
+# Build ostree with composefs support only if DISTRO_FEATURES "cfs" is set.
+PACKAGECONFIG:append = "${@bb.utils.contains('DISTRO_FEATURES', 'cfs', ' composefs', '', d)}"
+PACKAGECONFIG:append:class-native = "${@bb.utils.contains('DISTRO_FEATURES', 'cfs', ' composefs', '', d)}"
+
+
+# Ensure ed25519 is available for signing commits.
+PACKAGECONFIG:append = "${@bb.utils.contains('DISTRO_FEATURES', 'cfs-signed', ' ed25519-libsodium', '', d)}"
+PACKAGECONFIG:append:class-native = "${@bb.utils.contains('DISTRO_FEATURES', 'cfs-signed', ' ed25519-libsodium', '', d)}"
+
+
+# TODO: Upstream this addition.
+PACKAGECONFIG[composefs] = "--with-composefs, --without-composefs"
+
+# TODO: Upstream this addition.
+do_configure:prepend() {
+    cp ${S}/composefs/libcomposefs/Makefile-lib.am ${S}/composefs/libcomposefs/Makefile-lib.am.inc
+}
+
+# Disable PTEST for ostree as it requires options that are not enabled when
+# building with meta-updater
+PTEST_ENABLED = "0"
+
+# OSTREE_REPO_CFG_...: configurations to be set by "ostree config set <key>"
+# executed on the sysroot of the running device - operation performed by the
+# service ostree-repo-config.
+#
+# OSTREE_REPO_CFG_COMPOSEFS: related to key=ex-integrity.composefs (no|yes|maybe).
+# OSTREE_REPO_CFG_FSVERITY: related to key=ex-integrity.fsverity (no|yes|maybe).
+#
+OSTREE_REPO_CFG_COMPOSEFS_DEFAULT = ""
+OSTREE_REPO_CFG_COMPOSEFS_DEFAULT = "${@bb.utils.contains('DISTRO_FEATURES', 'cfs-signed', 'yes', bb.utils.contains('DISTRO_FEATURES', 'cfs', 'yes', '', d), d)}"
+OSTREE_REPO_CFG_COMPOSEFS ?= "${OSTREE_REPO_CFG_COMPOSEFS_DEFAULT}"
+
+OSTREE_REPO_CFG_FSVERITY_DEFAULT = ""
+
+OSTREE_REPO_CFG_FSVERITY_DEFAULT = "${@bb.utils.contains('DISTRO_FEATURES', 'cfs-signed', 'yes', bb.utils.contains('DISTRO_FEATURES', 'cfs', 'maybe', '', d), d)}"
+OSTREE_REPO_CFG_FSVERITY ?= "${OSTREE_REPO_CFG_FSVERITY_DEFAULT}"
+
+SYSTEMD_SERVICE:${PN}:append = "${@bb.utils.contains('DISTRO_FEATURES', 'cfs', ' ostree-repo-config.service', '', d)}"
+
+require ostree-prepare-root.inc
+
+do_install:append() {
+    if ${@bb.utils.contains('DISTRO_FEATURES', 'cfs', 'true', 'false', d)}; then
+        install -d ${D}${systemd_system_unitdir}
+        install -m 0644 /dev/null ${D}${nonarch_libdir}/ostree/prepare-root.conf
+        write_prepare_root_config ${D}${nonarch_libdir}/ostree/prepare-root.conf
+        install -m 0644 ${WORKDIR}/ostree-repo-config.service ${D}${systemd_system_unitdir}
+        install -d ${D}${sbindir}
+        install -m 0755 ${WORKDIR}/ostree-repo-config.sh ${D}${sbindir}
+        sed -e 's/@@OSTREE_REPO_CFG_COMPOSEFS@@/${OSTREE_REPO_CFG_COMPOSEFS}/' \
+            -e 's/@@OSTREE_REPO_CFG_FSVERITY@@/${OSTREE_REPO_CFG_FSVERITY}/' \
+            -i ${D}${sbindir}/ostree-repo-config.sh
+    fi
+}
+


### PR DESCRIPTION
This patch series introduces support for ComposeFS and fs-verity, targeting the Scarthgap Yocto release. The integration is gated through two new distro features: 'cfs' and 'cfs-signed'.

- `cfs`: Enables ComposeFS as the root filesystem format, leveraging its content-addressable, read-only design for improved boot performance and storage efficiency.
- `cfs-signed`: Extends 'cfs' by enabling fs-verity support, allowing cryptographic verification of file contents at runtime, enhancing system integrity and security.

Key changes:
- Added recipes and configuration for ComposeFS integration
- Enabled fs-verity support in the kernel and userland tools
- Conditional logic based on DISTRO_FEATURES to toggle ComposeFS and fs-verity
- Adjustments to image generation and initramfs to support ComposeFS boot

Signed-off-by: Sasi Kumar Maddineni <sasikuma@qti.qualcomm.com>