### PR TITLE
aktualizr: avoid failure on sed

### DIFF
--- a/recipes-sota/aktualizr/aktualizr_git.bb
+++ b/recipes-sota/aktualizr/aktualizr_git.bb
@@ -74,7 +74,7 @@ RESOURCE_MEMORY_MAX = "80%"
 
 # Remove TMPDIR references from asn1 files, generated as part of the build process
 do_compile:append() {
-    sed -i "s|${UNPACKDIR}/||g" ${B}/src/libaktualizr-posix/asn1/generated/asn1/*.[ch]
+    sed -i "s|${UNPACKDIR}/||g" ${B}/src/libaktualizr-posix/asn1/generated/asn1/*.[ch] || true
 }
 
 do_compile_ptest() {


### PR DESCRIPTION
Allow sed to not fail in case the asn1 files are not generated or generated in a separated folder (as done with aktualizr-lite).