### PR TITLE
kas: common-rpi: don't enable synaptics-killswitch by default

### DIFF
--- a/kas/common-rpi.yml
+++ b/kas/common-rpi.yml
@@ -14,6 +14,8 @@ repos:
 
 local_conf_header:
   license: |
-    LICENSE_FLAGS_ACCEPTED = "synaptics-killswitch"
+    # Uncomment next line to allow the license
+    # See: linux-firmware-rpidistro in meta-raspberrypi/docs/ipcompliance.md
+    #LICENSE_FLAGS_ACCEPTED = "synaptics-killswitch"
 
 machine: unset


### PR DESCRIPTION
Let the user decide if such license is OK from the build / deploy perspective.