### PR TITLE
RFC:cronie: let systemd-tmpfiles create /var/spool/cron

### DIFF
--- a/recipes-extended/cronie/cronie_%.bbappend
+++ b/recipes-extended/cronie/cronie_%.bbappend
@@ -1,0 +1,10 @@
+SRC_URI:append:sota = " file://cronie.conf "
+
+do_install:append:sota() {
+    if ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'true', 'false', d)}; then
+        install -d ${D}${sysconfdir}/tmpfiles.d
+        install -m 0644 ${WORKDIR}/cronie.conf ${D}${sysconfdir}/tmpfiles.d/cronie.conf
+        # Remove pre-created /var directory from package
+        (cd ${D}${localstatedir}; rmdir -v --parents spool/cron)
+    fi
+}

--- a/recipes-extended/cronie/files/cronie.conf
+++ b/recipes-extended/cronie/files/cronie.conf
@@ -1,0 +1,1 @@
+d /var/spool/cron 0770 root crontab -


### PR DESCRIPTION
Create /var/spool/cron/ at runtime using tmpfiles.d mechanism for systemd. Remove the directory if it is empty at build time to fix warnings when using