### PR TITLE
shadow: let systemd-tmpfiles create /var/spool/mail

### DIFF
--- a/recipes-extended/shadow/files/shadow.conf
+++ b/recipes-extended/shadow/files/shadow.conf
@@ -1,0 +1,1 @@
+d /var/spool/mail 0775 root mail -

--- a/recipes-extended/shadow/shadow_%.bbappend
+++ b/recipes-extended/shadow/shadow_%.bbappend
@@ -1,0 +1,14 @@
+FILESEXTRAPATHS:prepend:sota := "${THISDIR}/files:"
+
+SRC_URI:append:sota = " file://shadow.conf"
+
+do_install:append:sota() {
+    if ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'true', 'false', d)}; then
+        install -d ${D}${nonarch_libdir}/tmpfiles.d
+        install -m 0644 ${UNPACKDIR}/shadow.conf ${D}${nonarch_libdir}/tmpfiles.d/shadow.conf
+        # Remove pre-created /var/spool/mail directory from package
+        (cd ${D}${localstatedir}; rmdir -v --parents spool/mail)
+    fi
+}
+
+FILES:${PN} += "${nonarch_libdir}/tmpfiles.d"


### PR DESCRIPTION
OE-core configures mailboxes to be in ~/ but creates /var/spool/mail in case someone reconfigures MAIL_DIR later. To handle this, create /var/spool/mail/ at runtime using tmpfiles.d mechanism for systemd. Remove the directory if it is empty at build time to fix warnings when using systemd.