### PR TITLE
cronie: fixup FILESEXTRAPATHS and UNPACKDIR

### DIFF
--- a/recipes-extended/cronie/cronie_%.bbappend
+++ b/recipes-extended/cronie/cronie_%.bbappend
@@ -1,9 +1,11 @@
+FILESEXTRAPATHS:prepend:sota := "${THISDIR}/files:"
+
 SRC_URI:append:sota = " file://cronie.conf "
 
 do_install:append:sota() {
     if ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'true', 'false', d)}; then
         install -d ${D}${sysconfdir}/tmpfiles.d
-        install -m 0644 ${WORKDIR}/cronie.conf ${D}${sysconfdir}/tmpfiles.d/cronie.conf
+        install -m 0644 ${UNPACKDIR}/cronie.conf ${D}${sysconfdir}/tmpfiles.d/cronie.conf
         # Remove pre-created /var directory from package
         (cd ${D}${localstatedir}; rmdir -v --parents spool/cron)
     fi


### PR DESCRIPTION
Set FILESEXTRAPATHS to find the cronie.conf and replace the WORKDIR by UNPACKDIR