### PR TITLE
dhcpcd: let systemd-tmpfiles create /var/lib/dhcpcd

### DIFF
--- a/recipes-extended/dhcpcd/dhcpcd_%.bbappend
+++ b/recipes-extended/dhcpcd/dhcpcd_%.bbappend
@@ -1,0 +1,15 @@
+FILESEXTRAPATHS:prepend:sota := "${THISDIR}/files:"
+
+SRC_URI:append:sota = " file://dhcpcd.conf"
+
+do_install:append:sota() {
+    if [ "${DBDIR}" = "${localstatedir}/lib/${BPN}" ] && \
+           ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'true', 'false', d)}; then
+        install -d ${D}${nonarch_libdir}/tmpfiles.d
+        install -m 0644 ${UNPACKDIR}/dhcpcd.conf ${D}${nonarch_libdir}/tmpfiles.d/dhcpcd.conf
+        # Remove pre-created /var/lib/dhcpcd directory from package
+        (cd ${D}${localstatedir}; rmdir -v --parents lib/dhcpcd)
+    fi
+}
+
+FILES:${PN} += "${nonarch_libdir}/tmpfiles.d"

--- a/recipes-extended/dhcpcd/files/dhcpcd.conf
+++ b/recipes-extended/dhcpcd/files/dhcpcd.conf
@@ -1,0 +1,1 @@
+d /var/lib/dhcpcd 0700 dhcpcd dhcpcd -


### PR DESCRIPTION
Dhcpcd optionally creates /var/lib/dhcpcd with default DBDIR value.
To handle this, in case DBDIR is /var/lib/dhcpcd create /var/lib/dhcpcd at runtime using tmpfiles.d mechanism for systemd. Remove the directory if it is empty at build time to fix warnings when using systemd.