### PR TITLE
kas: rename qcs6490-rb3gen2-core-kit fragment

### DIFF
--- a/kas/rb3gen2-core-kit.yml
+++ b/kas/rb3gen2-core-kit.yml
@@ -5,4 +5,4 @@ header:
   includes:
   - kas/common-qcom.yml
 
-machine: qcs6490-rb3gen2-core-kit
+machine: rb3gen2-core-kit


### PR DESCRIPTION
Machine qcs6490-rb3gen2-core-kit was renamed to rb3gen2-core-kit in meta-qcom.

https://github.com/qualcomm-linux/meta-qcom/commit/421c4286f79a16d68be6fd659dbffed86515c301