### PR TITLE
networkmanager: delete empty state directory

### DIFF
--- a/recipes-extended/networkmanager/networkmanager_%.bbappend
+++ b/recipes-extended/networkmanager/networkmanager_%.bbappend
@@ -1,0 +1,4 @@
+do_install:append:sota() {
+        # Remove pre-created /var/lib/NetworkManager directory from package
+        (cd ${D}${localstatedir}; rmdir -v --parents lib/NetworkManager)
+}


### PR DESCRIPTION
NetworkManager creates /var/lib/NetworkManager at runtime [1] to ensure localstatedirs are present.

Remove it at build time if it is empty to fix warnings.

[1] https://github.com/NetworkManager/NetworkManager/blob/771f86105e7b937117fdd8e8dfd14761f4e4a869/src/core/main-utils.c#L93