### PR TITLE
systemd: delete empty systemd state directory

### DIFF
--- a/recipes-extended/systemd/systemd_%.bbappend
+++ b/recipes-extended/systemd/systemd_%.bbappend
@@ -1,0 +1,4 @@
+do_install:append:sota() {
+        # Remove pre-created /var/lib/systemd directory from package
+        (cd ${D}${localstatedir}; rmdir -v --parents lib/systemd)
+}


### PR DESCRIPTION
systemd creates /var/lib/systemd at runtime [1]
to ensure localstatedirs are present.

Remove it at build time if it is empty to fix warnings.

[1] https://github.com/systemd/systemd/blob/68ce283c3f4a63696307cee9addd7b6c333efbd5/tmpfiles.d/systemd.conf.in#L58