### PR TITLE
dbus: let systemd-tmpfiles handle creation of statedir

### DIFF
--- a/recipes-extended/dbus/dbus_%.bbappend
+++ b/recipes-extended/dbus/dbus_%.bbappend
@@ -1,0 +1,6 @@
+do_install:append:sota() {
+    if  ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'true', 'false', d)}; then
+        # Remove pre-created /var/lib/dbus directory from package
+        (cd ${D}${localstatedir}; rmdir -v --parents lib/dbus)
+    fi
+}


### PR DESCRIPTION
OE-core recipe [1] explicitly creates /var/lib/dbus and assigns user and group for it to messagebus:messagebus. dbus already has a tmpfiles [2] that creates the machine-id symlink and /var/lib/dbus directory if not present.
Create another tmpfiles that creates this directory at runtime and assigns the user group as per OE-core.
Remove the directory if it is empty at build time to fix warnings when using systemd.

[1] https://gitlab.freedesktop.org/dbus/dbus/-/blob/dbus-1.16/bus/tmpfiles.d/dbus.conf.in?ref_type=heads#L9
[2] https://git.openembedded.org/openembedded-core/tree/meta/recipes-core/dbus/dbus_1.16.2.bb?h=walnascar#n162