### PR TITLE
Disable DTB packaging in UKI on Qualcomm platforms.

### DIFF
--- a/classes/sota_qcom.bbclass
+++ b/classes/sota_qcom.bbclass
@@ -18,6 +18,9 @@ IMAGE_QCOMFLASH_FS_TYPE = "ota-ext4"
 
 EXTRA_IMAGECMD:ota-esp = "-s 1 -S ${QCOM_VFAT_SECTOR_SIZE}"
 
+# Remove DTB from UKI, rely on EFI provided one
+KERNEL_DEVICETREE = ""
+
 UKI_IMAGE_CLASS = "uki"
 # No support for UKI on armv7
 UKI_IMAGE_CLASS:qcom-armv7a = ""


### PR DESCRIPTION
On Qualcomm platforms, UEFI provides a compatible DTB via dtb.bin, which systemd-boot is expected to pass through to the Linux kernel. However, if a DTB is packaged inside the UKI, systemd-boot prioritizes this DTB over the one provided by UEFI, resulting in the kernel booting with an unintended device tree.

To avoid this, clear KERNEL_DEVICETREE while genrating esp.bin image so that the ukify tool skips DTB packaging in the UKI.