### PR TITLE
libvirt: extend var/lib removal logic

### DIFF
--- a/dynamic-layers/virtualization-layer/recipes-extended/libvirt/files/libvirt.conf
+++ b/dynamic-layers/virtualization-layer/recipes-extended/libvirt/files/libvirt.conf
@@ -16,6 +16,8 @@ d /var/lib/libvirt/qemu/nvram 0755 qemu qemu - -
 d /var/lib/libvirt/qemu/ram 0755 qemu qemu - -
 d /var/lib/libvirt/qemu/save 0755 qemu qemu - -
 d /var/lib/libvirt/qemu/snapshot 0755 qemu qemu - -
+d /var/lib/libvirt/qemu/varstore 0755 qemu qemu - -
+d /var/lib/libvirt/secrets 0755 root root - -
 d /var/lib/libvirt/swtpm 0755 root root - -
 d /var/cache/libvirt 0755 root root - -
 d /var/cache/libvirt/qemu 0755 root root - -

--- a/dynamic-layers/virtualization-layer/recipes-extended/libvirt/libvirt_%.bbappend
+++ b/dynamic-layers/virtualization-layer/recipes-extended/libvirt/libvirt_%.bbappend
@@ -19,7 +19,8 @@ do_install:append:sota() {
                 rmdir -v lib/libvirt/qemu/checkpoint lib/libvirt/qemu/dump;
                 rmdir -v lib/libvirt/qemu/nvram lib/libvirt/qemu/ram;
                 rmdir -v lib/libvirt/qemu/save lib/libvirt/qemu/snapshot;
-                rmdir -v lib/libvirt/qemu;
+                rmdir -v lib/libvirt/qemu/varstore lib/libvirt/qemu;
+                rmdir -v lib/libvirt/secrets;
                 rmdir -v lib/libvirt/swtpm;
                 rmdir -v --parents lib/libvirt;
                 rmdir -v --parents cache/libvirt/qemu;


### PR DESCRIPTION
Refresh var/lib removal logic based on the libvirt v12.1.0 update from meta-virtualization.