### PR TITLE
libvirt: set up secrets directory with 700 permissions

### DIFF
--- a/dynamic-layers/virtualization-layer/recipes-extended/libvirt/files/libvirt.conf
+++ b/dynamic-layers/virtualization-layer/recipes-extended/libvirt/files/libvirt.conf
@@ -17,7 +17,7 @@ d /var/lib/libvirt/qemu/ram 0755 qemu qemu - -
 d /var/lib/libvirt/qemu/save 0755 qemu qemu - -
 d /var/lib/libvirt/qemu/snapshot 0755 qemu qemu - -
 d /var/lib/libvirt/qemu/varstore 0755 qemu qemu - -
-d /var/lib/libvirt/secrets 0755 root root - -
+d /var/lib/libvirt/secrets 0700 root root - -
 d /var/lib/libvirt/swtpm 0755 root root - -
 d /var/cache/libvirt 0755 root root - -
 d /var/cache/libvirt/qemu 0755 root root - -


### PR DESCRIPTION
Directory containing secrets should be restricted to root user and 700 permissions [1].

[1] https://github.com/libvirt/libvirt/commit/97758bc9a0b1fccf8c0009308658f1204b113b89