### PR TITLE
sota_qcom: enable OSTree boot counting by default

### DIFF
--- a/classes/sota_qcom.bbclass
+++ b/classes/sota_qcom.bbclass
@@ -23,3 +23,7 @@ UKI_IMAGE_CLASS = "uki"
 UKI_IMAGE_CLASS:qcom-armv7a = ""
 IMAGE_CLASSES += "${UKI_IMAGE_CLASS}"
 IMAGE_CLASSES:remove:pn-initramfs-ostree-image = "${UKI_IMAGE_CLASS}"
+
+# Enable OSTree boot counting to generate correct BLS entry filenames (e.g. ostree-2+3.conf)
+OSTREE_REPO_CONFIG:append = " sysroot.boot-counting-tries:3"
+OSTREE_OTA_REPO_CONFIG:append = " sysroot.boot-counting-tries:3"


### PR DESCRIPTION
Set sysroot.boot-counting-tries=3 via ostree configuration to enable OSTree boot counting feature on Qcom platforms. Without this setting, BLS entries in /boot/loader/entries/ are generated as ostree-2.conf instead of the expected ostree-2+3.conf format, which is required for the automatic rollback mechanism to work correctly.