### PR TITLE
ostree: use 'uki' directive now that OE-core is on systemd v259

### DIFF
--- a/recipes-extended/ostree/ostree/0003-deploy-add-support-for-uki.patch
+++ b/recipes-extended/ostree/ostree/0003-deploy-add-support-for-uki.patch
@@ -263,7 +263,7 @@ index 34ea81e1..5230be10 100644
 +    {
 +      g_autofree char *boot_relpath
 +          = g_strconcat (bootprefix, bootcsumdir, "/", kernel_layout->uki_namever, NULL);
-+      ostree_bootconfig_parser_set (bootconfig, "efi", boot_relpath);
++      ostree_bootconfig_parser_set (bootconfig, "uki", boot_relpath);
 +    }
 +
    /* Note this is parsed in ostree-impl-system-generator.c */


### PR DESCRIPTION
Use the 'uki' directive instead of 'efi' when generating boot loader
entries for Unified Kernel Images so the loader entry reads:
```
  uki /ostree/poky-<hash>/uki-<ver>.efi
```

The 'uki' directive was added in systemd v258. At the time the
original patch was written, OE-core was using an older version.
Now that OE-core has moved to systemd v259, we can switch to
the correct 'uki' directive as per the Boot Loader Specification.