### PR TITLE
refpolicy-targeted: allow generator to read symlinks and manage runtime files

### DIFF
--- a/dynamic-layers/selinux/recipes-security/refpolicy/refpolicy-targeted/0001-refpolicy-Add-policy-module-for-ostree.patch
+++ b/dynamic-layers/selinux/recipes-security/refpolicy/refpolicy-targeted/0001-refpolicy-Add-policy-module-for-ostree.patch
@@ -50,7 +50,7 @@ index 000000000..ae78c4ebb
 +/media                    -l          gen_context(system_u:object_r:mnt_t,s0)
 +/mnt                      -l          gen_context(system_u:object_r:mnt_t,s0)
 +/opt                      -l          gen_context(system_u:object_r:usr_t,s0)
-+
++/home/root                            gen_context(system_u:object_r:home_root_t,s0)
 +# /sysroot/ostree itself, plus the boot loader pointers (boot.X is a
 +# symlink to boot.X.Y; boot.X.Y/<osname>/<hash>/{0,1} are the loader
 +# symlinks ostree resolves at admin-status time) and the intermediate

--- a/dynamic-layers/selinux/recipes-security/refpolicy/refpolicy-targeted/0002-systemd-allow-generator-to-read-symlinks-and-manage-.patch
+++ b/dynamic-layers/selinux/recipes-security/refpolicy/refpolicy-targeted/0002-systemd-allow-generator-to-read-symlinks-and-manage-.patch
@@ -1,0 +1,39 @@
+From 1f490095f771d1fdcf942cf788d7a3f2a859f3a3 Mon Sep 17 00:00:00 2001
+From: Jaihind Yadav <jaihindy@qti.qualcomm.com>
+Date: Fri, 22 May 2026 14:53:13 +0530
+Subject: [PATCH] refpolicy-targeted: allow generator to read symlinks and
+manage runtime files
+
+Systemd generator triggers AVC denials when accessing /usr symlinks
+and creating runtime files during early boot.
+
+Add required interfaces to allow:
+  - reading /usr symlinks
+  - creating runtime files under init context
+  - mounting tmpfs
+
+Also label /home/root with home_root_t for correct access handling.
+
+Upstream-Status: Inappropriate [meta-updater specific]
+
+Signed-off-by: Jaihind Yadav <jaihindy@qti.qualcomm.com>
+---
+ policy/modules/system/systemd.te | 5 +++++
+ 1 files changed, 5 insertions(+)
+
+diff --git a/policy/modules/system/systemd.te b/policy/modules/system/systemd.te
+index 2f2851455..b6137982f 100644
+--- a/policy/modules/system/systemd.te
++++ b/policy/modules/system/systemd.te
+@@ -692,6 +692,11 @@ userdom_use_user_ttys(systemd_generator_t)
+ mls_file_read_to_clearance(systemd_generator_t)
+ mls_file_write_to_clearance(systemd_generator_t)
+ 
++#these changes are needed to create var/rootdirs/home in ostree
++files_read_usr_symlinks(systemd_generator_t)
++init_manage_runtime_files(systemd_generator_t)
++fs_mount_tmpfs(systemd_generator_t)
++
+ ifdef(`distro_gentoo',`
+ 	corecmd_shell_entry_type(systemd_generator_t)
+ ')

--- a/dynamic-layers/selinux/recipes-security/refpolicy/refpolicy-targeted_git.bbappend
+++ b/dynamic-layers/selinux/recipes-security/refpolicy/refpolicy-targeted_git.bbappend
@@ -4,4 +4,5 @@ POLICY_STORE_ROOT:sota = "${sysconfdir}/selinux"
 
 SRC_URI:append:sota = " \
         file://0001-refpolicy-Add-policy-module-for-ostree.patch \
+        file://0002-systemd-allow-generator-to-read-symlinks-and-manage-.patch \
         "


### PR DESCRIPTION
Systemd generator triggers AVC denials when accessing /usr symlinks and creating runtime files during early boot.

Add required interfaces to allow:
  - reading /usr symlinks
  - creating runtime files under init context
  - mounting tmpfs

Also label /home/root with home_root_t for correct access handling in ostree.