### PR TITLE
kas: add selinux.yml

### DIFF
--- a/kas/selinux.yml
+++ b/kas/selinux.yml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/siemens/kas/master/kas/schema-kas.json
+
+header:
+  version: 14
+
+repos:
+  meta-selinux:
+    url: https://git.yoctoproject.org/meta-selinux
+
+local_conf_header:
+  selinux: |
+    DISTRO_FEATURES:append = " selinux"
+    DISTRO_FEATURES_FILTER_NATIVE:append = " selinux"
+    DISTRO_EXTRA_RDEPENDS:append = " packagegroup-core-selinux"
+    IMAGE_CLASSES += "selinux-image"
+    DISTRO_NAME:append = " (SELinux-enabled)"


### PR DESCRIPTION
Add kas selinux.yml fragment that includes meta-selinux and the required distro changes for proper enablement.

Fragment done to facilitate the testing and integration of selinux-specific logic and changes.