### PR TITLE
ostree: Exclude /usr/etc in OSTree build-time relabel

### DIFF
--- a/classes/image_types_ostree_selinux.bbclass
+++ b/classes/image_types_ostree_selinux.bbclass
@@ -8,7 +8,7 @@ IMAGE_CMD:ostree:append() {
         FC_PATH=${OSTREE_ROOTFS}/usr/etc/selinux/${POL_TYPE}/contexts/files/file_contexts
 
         if [ -n "${POL_TYPE}" ] && [ -f ${FC_PATH} ]; then
-            if ! setfiles -m -r ${OSTREE_ROOTFS} ${FC_PATH} ${OSTREE_ROOTFS}; then
+            if ! setfiles -m -r ${OSTREE_ROOTFS} ${FC_PATH} ${OSTREE_ROOTFS} -e ${OSTREE_ROOTFS}/usr/etc; then
                 bbwarn "Failed to set SELinux contexts on OSTree rootfs staging tree"
             fi
         else


### PR DESCRIPTION
In our build flow, SELinux labels are already applied earlier on the regular rootfs tree before OSTree conversion, and those xattrs are carried forward into the OSTree tree.Relabeling /usr/etc again in the OSTree pass overwrites previously-correct labels for configuration content with generic etc_t, which breaks expected SELinux labeling on deployed /etc.

Fix by excluding /usr/etc from the OSTree build-time relabel, so existing labels from the earlier rootfs labeling stage are preserved and not clobbered.