### PR TITLE
image_types_ostree_selinux: fix missing SELinux label on /usr/etc/tmp…

### DIFF
--- a/classes/image_types_ostree_selinux.bbclass
+++ b/classes/image_types_ostree_selinux.bbclass
@@ -11,6 +11,14 @@ IMAGE_CMD:ostree:append() {
             if ! setfiles -m -r ${OSTREE_ROOTFS} ${FC_PATH} ${OSTREE_ROOTFS} -e ${OSTREE_ROOTFS}/usr/etc; then
                 bbwarn "Failed to set SELinux contexts on OSTree rootfs staging tree"
             fi
+            # /usr/etc/tmpfiles.d is created during OSTree layout conversion (after
+            # the earlier rootfs labeling pass) so it carries no xattrs yet.
+            # Re-label it explicitly to give systemd-tmpfiles the correct context.
+            if [ -d ${OSTREE_ROOTFS}/usr/etc/tmpfiles.d ]; then
+                if ! setfiles -m -r ${OSTREE_ROOTFS} ${FC_PATH} ${OSTREE_ROOTFS}/usr/etc/tmpfiles.d; then
+                    bbwarn "Failed to set SELinux contexts on ${OSTREE_ROOTFS}/usr/etc/tmpfiles.d"
+                fi
+            fi
         else
             bbwarn "Missing SELINUXTYPE or file_contexts under ${OSTREE_ROOTFS}/usr/etc/selinux; skipping OSTree build-time labeling"
         fi


### PR DESCRIPTION
The -e /usr/etc exclusion in the OSTree build-time relabel pass is intentional: /usr/etc is populated from the regular rootfs tree whose files already carry correct SELinux xattrs from an earlier labeling stage, and re-running setfiles over them would overwrite those labels with generic etc_t.

However /usr/etc/tmpfiles.d is created during OSTree layout conversion (after the rootfs labeling pass) so it has no xattrs at all.  At runtime systemd-tmpfiles runs as systemd_tmpfiles_t and is denied access to files and directories carrying unlabeled_t, so /var/rootdirs/mnt, /var/rootdirs/media, /var/rootdirs/opt and /var/rootdirs/srv are never created.  This leaves the corresponding root symlinks dangling and makes mounts to /mnt fail.

Fix by keeping the broad -e /usr/etc exclusion intact (preserving existing labels on the carried-over /etc content) and adding a targeted second setfiles call that labels only /usr/etc/tmpfiles.d, the one subtree that genuinely needs labeling at this stage.