### PR TITLE
ostree: disable ptest for sota builds

### DIFF
--- a/recipes-extended/ostree/ostree_2026.1.bbappend
+++ b/recipes-extended/ostree/ostree_2026.1.bbappend
@@ -6,6 +6,11 @@ PACKAGECONFIG:remove = "gpgme"
 # static requires running as pid1
 PACKAGECONFIG:remove = "static"
 
+# meta-updater builds ostree without the options its ptest suite needs, so
+# disable ptest for sota (meta-updater) configurations. The ':sota' override
+# is set by sota.bbclass when 'sota' is in DISTRO_FEATURES.
+PTEST_ENABLED:sota = "0"
+
 # Conditional as sdboot support is not yet available upstream
 SD_BOOT_PATCHES = " \
     file://0001-Add-support-for-directories-instead-of-symbolic-link.patch \


### PR DESCRIPTION
The ostree ptest suite requires build options that are not enabled when ostree is built within meta-updater, so it fails to build. Disable ptest only for sota configurations -- the ':sota' override is set by sota.bbclass when 'sota' is in DISTRO_FEATURES -- instead of disabling it unconditionally, so ostree builds outside of meta-updater keep their ptest behaviour.