### PR TITLE
image_types_ostree: add --generate-sizes to ostree commit

### DIFF
--- a/classes/image_types_ostree.bbclass
+++ b/classes/image_types_ostree.bbclass
@@ -160,6 +160,7 @@ IMAGE_CMD:ostreecommit () {
     ostree_target_hash=$(ostree --repo=${OSTREE_REPO} commit \
            --tree=dir=${OSTREE_ROOTFS} \
            --skip-if-unchanged \
+           --generate-sizes \
            --branch=${OSTREE_BRANCHNAME} \
            --subject="${OSTREE_COMMIT_SUBJECT}" \
            --body="${OSTREE_COMMIT_BODY}" \


### PR DESCRIPTION
--generate-sizes embeds a sizes index in the commit metadata mapping each object to its (compressed/uncompressed) size. OTA clients such as aktualizr can use this to compute the total download size and required disk space for a target before pulling it, instead of having to fetch every object first to find out.
The disadvantage is the increase of the commit object size: 36 bytes per object it references.