### PR TITLE
systemd: drop systemd_%.bbappend

### DIFF
--- a/recipes-extended/systemd/systemd_%.bbappend
+++ b/recipes-extended/systemd/systemd_%.bbappend
@@ -1,4 +1,0 @@
-do_install:append:sota() {
-        # Remove pre-created /var/lib/systemd directory from package
-        (cd ${D}${localstatedir}; rmdir -v --parents lib/systemd)
-}


### PR DESCRIPTION
Upstream systemd stopped creating an empty /var/lib/systemd directory at install time [1], relying solely on tmpfiles.d to create it at boot instead. The unguarded rmdir here now unconditionally fails do_install since the directory never exists, and the cleanup itself is no longer needed for any supported systemd version.

[1] https://github.com/systemd/systemd/commit/9013347ba956c0c2f34f011c54f421a13912b7ab