### PR TITLE
bootimg_sota_efi: drop the dependency on oe.path

### DIFF
--- a/scripts/lib/wic/plugins/source/bootimg_sota_efi.py
+++ b/scripts/lib/wic/plugins/source/bootimg_sota_efi.py
@@ -14,8 +14,8 @@ import logging
 import os
 import shutil
 import re
+import subprocess
 
-from oe.path import copyhardlinktree
 from glob import glob
 
 from wic import WicError
@@ -25,6 +25,25 @@ from wic.misc import (exec_cmd, exec_native_cmd,
                       get_bitbake_var, BOOTDD_EXTRA_SPACE)
 
 logger = logging.getLogger('wic')
+
+
+# wic runs from its own installed package, where oe-core's Python libraries are
+# out of reach, so the hard-link copy it needs lives here.
+def copyhardlinktree(src, dst):
+    """Hard-link the tree at src into dst, copying where links cannot reach."""
+    os.makedirs(dst, exist_ok=True)
+
+    if os.path.isdir(src) and not os.listdir(src):
+        return
+
+    contents = os.path.join(src, ".")
+    try:
+        subprocess.check_output(["cp", "-afl", "--preserve=xattr", contents, dst],
+                                stderr=subprocess.STDOUT)
+    except subprocess.CalledProcessError:
+        logger.debug("Hard-linking %s failed; falling back to a copy", src)
+        subprocess.check_output(["cp", "-af", "--preserve=xattr", contents, dst],
+                                stderr=subprocess.STDOUT)
 
 class BootimgSotaEFIPlugin(SourcePlugin):
     """


### PR DESCRIPTION
A build error (on master) was faced while trying to build `qemuarm64-secureboot.conf` with `meta-updater` included in `bblayers.conf`

which is basically:
```
QB_DEFAULT_FSTYPE = "wic.qcow2"
QB_DEFAULT_BIOS   = "flash.bin"
IMAGE_FSTYPES    += "wic wic.qcow2"
WKS_FILE         ?= "qemuarm64.wks"
```

This was the build error:

```
File ".../meta-updater/scripts/lib/wic/plugins/source/bootimg_sota_efi.py", line 18
    from oe.path import copyhardlinktree
ModuleNotFoundError: No module named 'oe'
```

So, the patch fix the build error, but I could not test if the `copyhardlinktree` actually do what it is supposed to do, as I don't have the ways to test it before/after.

If the PR is not the right way to fix the problem, it can be moved to an issue reporting the build failure.