### PR TITLE
ostree-var-relabel: relabel /var on SELinux policy change

### DIFF
--- a/classes/sota.bbclass
+++ b/classes/sota.bbclass
@@ -7,7 +7,8 @@ SOTA_HARDWARE_ID ??= "${MACHINE}"
 IMAGE_CLASSES += " image_types_ostree image_types_ota image_repo_manifest"
 IMAGE_INSTALL:append:sota = " aktualizr aktualizr-info ${SOTA_CLIENT_PROV} \
                               ostree os-release ostree-kernel ostree-initramfs \
-                              ${@'ostree-devicetrees' if oe.types.boolean('${OSTREE_DEPLOY_DEVICETREE}') else ''}"
+                              ${@'ostree-devicetrees' if oe.types.boolean('${OSTREE_DEPLOY_DEVICETREE}') else ''} \
+                              ${@bb.utils.contains('DISTRO_FEATURES', 'selinux systemd', 'ostree-var-relabel', '', d)}"
 
 IMAGE_FSTYPES += "${@bb.utils.contains('DISTRO_FEATURES', 'sota', 'ostreepush garagesign garagecheck ota-ext4', ' ', d)}"
 IMAGE_FSTYPES += "${@bb.utils.contains('BUILD_OSTREE_TARBALL', '1', 'ostree.tar.bz2', ' ', d)}"

--- a/dynamic-layers/selinux/recipes-sota/ostree-var-relabel/ostree-var-relabel.bb
+++ b/dynamic-layers/selinux/recipes-sota/ostree-var-relabel/ostree-var-relabel.bb
@@ -1,0 +1,37 @@
+SUMMARY = "Relabel /var when the SELinux policy changes across OSTree deployments"
+DESCRIPTION = "/var is shared across OSTree deployments and is only labeled \
+once by libostree, at deploy time, while the previous deployment's policy is \
+still loaded.  This service detects a policy change on boot and relabels /var \
+with the policy of the booted deployment, covering updates and rollbacks that \
+ship a different SELinux policy."
+LICENSE = "MPL-2.0"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MPL-2.0;md5=815ca599c9df247a0c7f619bab123dad"
+
+inherit systemd features_check
+
+REQUIRED_DISTRO_FEATURES = "systemd selinux"
+
+SRC_URI = " \
+  file://ostree-var-relabel \
+  file://ostree-var-relabel.service \
+  "
+
+S = "${UNPACKDIR}"
+
+SYSTEMD_SERVICE:${PN} = "ostree-var-relabel.service"
+
+do_install() {
+    install -d ${D}${libexecdir}
+    install -m 0755 ${UNPACKDIR}/ostree-var-relabel ${D}${libexecdir}/ostree-var-relabel
+
+    install -d ${D}${systemd_system_unitdir}
+    install -m 0644 ${UNPACKDIR}/ostree-var-relabel.service ${D}${systemd_system_unitdir}/ostree-var-relabel.service
+    sed -i -e 's,/usr/libexec/,${libexecdir}/,g' ${D}${systemd_system_unitdir}/ostree-var-relabel.service
+}
+
+FILES:${PN} = " \
+        ${libexecdir}/ostree-var-relabel \
+        ${systemd_system_unitdir}/ostree-var-relabel.service \
+        "
+
+RDEPENDS:${PN} += "policycoreutils-setfiles"

--- a/dynamic-layers/selinux/recipes-sota/ostree-var-relabel/ostree-var-relabel/ostree-var-relabel
+++ b/dynamic-layers/selinux/recipes-sota/ostree-var-relabel/ostree-var-relabel/ostree-var-relabel
@@ -1,0 +1,31 @@
+#!/bin/sh
+# SPDX-License-Identifier: MPL-2.0
+#
+# Relabel /var when the SELinux policy of the booted deployment differs
+# from the policy that last labeled /var.
+#
+# /var is shared across OSTree deployments and libostree only labels it
+# once ever, at deploy time (guarded by /var/.ostree-selabeled), while the
+# previous deployment's policy is still loaded in the kernel.  When an
+# update or a rollback changes the SELinux policy, the labels in /var go
+# stale and can only be fixed with the new policy active, i.e. at boot.
+
+STAMP=/var/.selinux-policy-checksum
+
+policytype=$(sed -n 's/^SELINUXTYPE=//p' /etc/selinux/config)
+[ -n "$policytype" ] || exit 0
+
+set -- /etc/selinux/"$policytype"/policy/policy.*
+[ -f "$1" ] || exit 0
+
+csum=$(cat /etc/selinux/"$policytype"/policy/policy.* \
+           /etc/selinux/"$policytype"/contexts/files/file_contexts* 2>/dev/null | \
+           sha256sum | cut -d ' ' -f 1)
+
+if [ -f "$STAMP" ] && [ "$(cat "$STAMP")" = "$csum" ]; then
+    exit 0
+fi
+
+echo "SELinux policy changed, relabeling /var"
+restorecon -RF /var || exit 1
+echo "$csum" > "$STAMP"

--- a/dynamic-layers/selinux/recipes-sota/ostree-var-relabel/ostree-var-relabel/ostree-var-relabel.service
+++ b/dynamic-layers/selinux/recipes-sota/ostree-var-relabel/ostree-var-relabel/ostree-var-relabel.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Relabel /var on SELinux policy change
+DefaultDependencies=no
+ConditionSecurity=selinux
+RequiresMountsFor=/var
+After=systemd-remount-fs.service local-fs.target
+Before=sysinit.target systemd-tmpfiles-setup.service systemd-update-done.service shutdown.target
+Conflicts=shutdown.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+TimeoutStartSec=infinity
+ExecStart=/usr/libexec/ostree-var-relabel
+
+[Install]
+WantedBy=sysinit.target


### PR DESCRIPTION
/var is shared across OSTree deployments and libostree only labels it once ever, at deploy time, guarded by the /var/.ostree-selabeled stamp. That labeling runs while the previous deployment's policy is still loaded in the kernel, and is skipped entirely on systems deployed from factory images, where the stamp is created at image build time.

When an update ships a different SELinux policy, the contents of /var keep the labels from the previous policy (or no labels at all when the previous deployment ran permissive), and the first enforcing boot then denies services access to their own state directories, for example NetworkManager on /var/lib/NetworkManager.  Rolling back to the previous deployment has the same problem in the other direction.

meta-selinux's autorelabel mechanism cannot help here as it triggers on /.autorelabel, which lives in the read-only deployment root.

Add a oneshot early boot service that hashes the booted deployment's binary policy and file contexts, compares it against the hash stored in /var from the previous boot, and runs restorecon -RF /var on mismatch, before sysinit.target and systemd-tmpfiles-setup.service so no service touches /var with stale labels.  The relabel only runs when the policy actually changed, so regular boots and policy-neutral updates pay one checksum of a few megabytes.

Assisted-by: Claude Code:claude-fable-5