### PR TITLE
wic: bootimg_sota_efi: fix oe.path import for wic >= 0.3.1

### DIFF
--- a/scripts/lib/wic/plugins/source/bootimg_sota_efi.py
+++ b/scripts/lib/wic/plugins/source/bootimg_sota_efi.py
@@ -15,7 +15,6 @@ import os
 import shutil
 import re
 
-from oe.path import copyhardlinktree
 from glob import glob
 
 from wic import WicError
@@ -23,6 +22,7 @@ from wic.engine import get_custom_config
 from wic.pluginbase import SourcePlugin
 from wic.misc import (exec_cmd, exec_native_cmd,
                       get_bitbake_var, BOOTDD_EXTRA_SPACE)
+from wic.oe.path import copyhardlinktree
 
 logger = logging.getLogger('wic')
 


### PR DESCRIPTION
wic now vendors its own oe/bb helpers as wic.oe/wic.bb (commit bc0a8d88f6 [1], to stop colliding with oe-core's real oe package on PYTHONPATH). This plugin's import was never updated, so wic's unconditional plugin-scan crashes on load:
ModuleNotFoundError: No module named 'oe'.

Matches the import style wic's own plugins (direct.py, rootfs.py) already use.

[1] https://git.yoctoproject.org/wic/commit/?id=bc0a8d88f6cd72eaa58ff906634e8d8f8d08d82a