### PR TITLE
systemd: stop boot.mount gating local-fs.target on SOTA

### DIFF
--- a/recipes-core/systemd/systemd/boot.mount-10-no-local-fs-gate.conf
+++ b/recipes-core/systemd/systemd/boot.mount-10-no-local-fs-gate.conf
@@ -1,0 +1,21 @@
+# Boot-time optimization for SOTA/OSTree systems.
+#
+# systemd-gpt-auto-generator creates boot.automount and its backing boot.mount
+# for the EFI System Partition. OSTree's boot-complete service is pulled into
+# the boot transaction and RequiresMountsFor=/boot, which also pulls in the
+# backing mount. A normal local mount receives Before=local-fs.target through
+# its default dependencies, so a delayed ESP device unit can unnecessarily
+# hold local-fs.target and sysinit.target on the critical path.
+#
+# Keep the automount as the local-fs synchronization point and allow the real
+# mount to complete independently. Services that need /boot still wait for it
+# through RequiresMountsFor= or through an autofs access.
+#
+# DefaultDependencies=no also removes the local-fs-pre and shutdown ordering;
+# preserve those relationships explicitly and omit only the
+# Before=local-fs.target dependency.
+[Unit]
+DefaultDependencies=no
+After=local-fs-pre.target
+Conflicts=umount.target
+Before=umount.target

--- a/recipes-core/systemd/systemd_%.bbappend
+++ b/recipes-core/systemd/systemd_%.bbappend
@@ -1,0 +1,13 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+SRC_URI:append:sota = " \
+        file://boot.mount-10-no-local-fs-gate.conf \
+"
+
+do_install:append:sota() {
+        install -d ${D}${systemd_system_unitdir}/boot.mount.d
+        install -m 0644 ${UNPACKDIR}/boot.mount-10-no-local-fs-gate.conf \
+                ${D}${systemd_system_unitdir}/boot.mount.d/10-no-local-fs-gate.conf
+}
+
+FILES:${PN}:append:sota = " ${systemd_system_unitdir}/boot.mount.d/10-no-local-fs-gate.conf"


### PR DESCRIPTION
## Summary

Decouple the GPT-auto-generated `boot.mount` from `local-fs.target` on SOTA/OSTree systems. This prevents delayed EFI System Partition device activation from unnecessarily holding `local-fs.target` on the boot critical path.

## Background

`systemd-gpt-auto-generator` creates `boot.automount` and its backing `boot.mount` for the EFI System Partition. The OSTree generator pulls `ostree-boot-complete.service` into `multi-user.target`. Its `RequiresMountsFor=/boot` dependency brings the backing `boot.mount` into the boot transaction, even when the service is later skipped by its conditions.

A normal local mount receives `Before=local-fs.target` through systemd's default mount dependencies. Consequently, delayed activation of the ESP block device makes `boot.mount` gate `local-fs.target`, even though `/boot` is exposed through `boot.automount` and is otherwise mounted on demand.

## Change

Install a SOTA-scoped `boot.mount` drop-in that:

- sets `DefaultDependencies=no`;
- restores `After=local-fs-pre.target`;
- restores `Conflicts=umount.target` and `Before=umount.target`; and
- deliberately does not restore `Before=local-fs.target`.

`boot.automount` remains ordered before `local-fs.target` and continues to provide the autofs mount point. Consumers that require the backing filesystem still wait through `RequiresMountsFor=/boot` or by accessing `/boot`.

The change does not make `boot.mount` or ESP device discovery faster. It allows their wait time to overlap with unrelated system initialization.

## Results

- Platform: RB3 Gen 2 Core Kit `QLI.2.0 TAG wrynose-260627.1`

With the stock dependency graph, `local-fs.target` completed immediately after `boot.mount`, confirming that the ESP mount was its effective gate. With the drop-in, `local-fs.target` completed before `boot.mount`, confirming that the
dependency was removed.

Timing measured from the systemd boot plots:

| Metric | Default | With drop-in | Improvement |
| --- | ---: | ---: | ---: |
| `init.scope` to `local-fs.target` | 2573 ms | 1416 ms | 1158 ms |
| `init.scope` to `sysinit.target` | 2951 ms | 2418 ms | 533 ms |

## Validation

- `boot.mount` no longer has `Before=local-fs.target`.
- `boot.mount` retains `After=local-fs-pre.target`.
- Shutdown unmount ordering is preserved.
- `boot.automount` remains the `local-fs.target` synchronization point.
- OSTree consumers continue to wait for `/boot` through
  `RequiresMountsFor=/boot` or autofs access.
- The recipe change is restricted to the `sota` override.