### PR TITLE
classes/sota: only push to the update server when credentials are set

### DIFF
--- a/classes/image_types_ostree.bbclass
+++ b/classes/image_types_ostree.bbclass
@@ -173,9 +173,6 @@ IMAGE_CMD:ostreecommit () {
     fi
 }
 
-# Warn users about missing SOTA_PACKED_CREDENTIALS by default.
-SOTA_SKIP_CRED_WARN ?= "0"
-
 IMAGE_TYPEDEP:ostreepush = "ostreecommit"
 do_image_ostreepush[depends] += "aktualizr-native:do_populate_sysroot ca-certificates-native:do_populate_sysroot"
 do_image_ostreepush[lockfiles] += "${OSTREE_REPO}/ostree.lock"
@@ -190,8 +187,6 @@ IMAGE_CMD:ostreepush () {
         else
             bbwarn "SOTA_PACKED_CREDENTIALS file does not exist."
         fi
-    elif [ "${SOTA_SKIP_CRED_WARN}" != "1" ]; then
-        bbwarn "SOTA_PACKED_CREDENTIALS not set. Please add SOTA_PACKED_CREDENTIALS."
     fi
 }
 

--- a/classes/sota.bbclass
+++ b/classes/sota.bbclass
@@ -2,7 +2,11 @@ DISTROOVERRIDES .= "${@bb.utils.contains('DISTRO_FEATURES', 'sota', ':sota', '',
 
 SOTA_CLIENT_PROV ??= "aktualizr-shared-prov"
 SOTA_DEPLOY_CREDENTIALS ?= "1"
+SOTA_SKIP_CRED_WARN ?= "0"
 SOTA_HARDWARE_ID ??= "${MACHINE}"
+
+SOTA_PUSH_FSTYPES = "${@'ostreepush garagesign garagecheck' if d.getVar('SOTA_PACKED_CREDENTIALS') else ''}"
+SOTA_PUSH_FSTYPES[vardepvalue] = "${SOTA_PUSH_FSTYPES}"
 
 IMAGE_CLASSES += " image_types_ostree image_types_ota image_repo_manifest"
 IMAGE_INSTALL:append:sota = " aktualizr aktualizr-info ${SOTA_CLIENT_PROV} \
@@ -10,7 +14,8 @@ IMAGE_INSTALL:append:sota = " aktualizr aktualizr-info ${SOTA_CLIENT_PROV} \
                               ${@'ostree-devicetrees' if oe.types.boolean('${OSTREE_DEPLOY_DEVICETREE}') else ''} \
                               ${@bb.utils.contains('DISTRO_FEATURES', 'selinux systemd', 'ostree-var-relabel', '', d)}"
 
-IMAGE_FSTYPES += "${@bb.utils.contains('DISTRO_FEATURES', 'sota', 'ostreepush garagesign garagecheck ota-ext4', ' ', d)}"
+IMAGE_FSTYPES += "${@bb.utils.contains('DISTRO_FEATURES', 'sota', 'ota-ext4', ' ', d)}"
+IMAGE_FSTYPES += "${@bb.utils.contains('DISTRO_FEATURES', 'sota', '${SOTA_PUSH_FSTYPES}', ' ', d)}"
 IMAGE_FSTYPES += "${@bb.utils.contains('BUILD_OSTREE_TARBALL', '1', 'ostree.tar.bz2', ' ', d)}"
 IMAGE_FSTYPES += "${@bb.utils.contains('BUILD_OSTREE_REPO_TARBALL', '1', 'ostreecommit.tar.xz', ' ', d)}"
 IMAGE_FSTYPES += "${@bb.utils.contains('BUILD_OTA_TARBALL', '1', 'ota.tar.xz', ' ', d)}"

--- a/classes/sota_sanity.bbclass
+++ b/classes/sota_sanity.bbclass
@@ -54,6 +54,9 @@ def sota_check_variables_validity(status, d):
         path = os.path.abspath(credentials)
         if not os.path.exists(path):
             status.addresult("SOTA_PACKED_CREDENTIALS is not set correctly. The zipped credentials file does not exist.\n")
+    elif d.getVar("SOTA_SKIP_CRED_WARN") != "1":
+        bb.warn("SOTA_PACKED_CREDENTIALS is not set, so this build will not push to "
+                "an update server. Set SOTA_SKIP_CRED_WARN = \"1\" to silence this.")
     if not sota_check_boolean_variable("OSTREE_UPDATE_SUMMARY", d):
         status.addresult("OSTREE_UPDATE_SUMMARY (=%s) should be set to yes/y/true/t/1 or no/n/false/f/0.\n" % d.getVar("OSTREE_UPDATE_SUMMARY"))
     if not sota_check_boolean_variable("OSTREE_DEPLOY_DEVICETREE", d):


### PR DESCRIPTION
ostreepush, garagesign and garagecheck are added to IMAGE_FSTYPES for every sota distro, but all three are no-ops without SOTA_PACKED_CREDENTIALS: each IMAGE_CMD is wrapped in a test for it. What they still do is spawn a task per image and take ${OSTREE_REPO}/ostree.lock and
${DEPLOY_DIR_IMAGE}/garagesign.lock, so a build producing several images serialises them against each other and against do_image_ostreecommit for no result. On a three-image build that was 781 seconds of task wall time spent waiting on the OSTree lock alone. The layer's own selftests already work around this: every case but one appends
IMAGE_FSTYPES:remove = "ostreepush garagesign garagecheck".

Add the three image types only when SOTA_PACKED_CREDENTIALS is set, and move the warning about it being unset into the sota sanity check, which reports it once per build instead of once per image and still honours SOTA_SKIP_CRED_WARN. ostreecommit is still reached through ota-ext4 -> ota, so ${OSTREE_REPO} is populated exactly as before.

Compute the list through SOTA_PUSH_FSTYPES instead of testing SOTA_PACKED_CREDENTIALS inside IMAGE_FSTYPES directly. IMAGE_FSTYPES is part of do_rootfs[vardeps], so a reference there makes the credentials path itself part of the do_rootfs basehash and moving the credentials file rebuilds the rootfs and every image on top of it. The vardepvalue flag hashes the resulting fstype list rather than the path, so only whether credentials are set is signature relevant.

Assisted-by: Claude Code:claude-fable-5