### PR TITLE
classes/sota: compress the OSTree tarballs with zstd

### DIFF
--- a/classes/sota.bbclass
+++ b/classes/sota.bbclass
@@ -16,8 +16,8 @@ IMAGE_INSTALL:append:sota = " aktualizr aktualizr-info ${SOTA_CLIENT_PROV} \
 
 IMAGE_FSTYPES += "${@bb.utils.contains('DISTRO_FEATURES', 'sota', 'ota-ext4', ' ', d)}"
 IMAGE_FSTYPES += "${@bb.utils.contains('DISTRO_FEATURES', 'sota', '${SOTA_PUSH_FSTYPES}', ' ', d)}"
-IMAGE_FSTYPES += "${@bb.utils.contains('BUILD_OSTREE_TARBALL', '1', 'ostree.tar.bz2', ' ', d)}"
-IMAGE_FSTYPES += "${@bb.utils.contains('BUILD_OSTREE_REPO_TARBALL', '1', 'ostreecommit.tar.xz', ' ', d)}"
+IMAGE_FSTYPES += "${@bb.utils.contains('BUILD_OSTREE_TARBALL', '1', 'ostree.tar.zst', ' ', d)}"
+IMAGE_FSTYPES += "${@bb.utils.contains('BUILD_OSTREE_REPO_TARBALL', '1', 'ostreecommit.tar.zst', ' ', d)}"
 IMAGE_FSTYPES += "${@bb.utils.contains('BUILD_OTA_TARBALL', '1', 'ota.tar.xz', ' ', d)}"
 
 WKS_FILE:sota ?= "sdimage-sota.wks"


### PR DESCRIPTION
bzip2 and xz are a poor trade for these two. Over sixteen threads the 2019 MiB repository tarball costs 805 CPU seconds with xz -6 to save 85 MiB, where zstd needs 6; the 2710 MiB rootfs tarball costs 155 CPU seconds with bzip2, where zstd needs 11. Both come out 1-3% larger.

Switch both to zstd. ota.tar.xz is left alone, as it tars an uncompressed deployment where xz still earns its cost.

Note this renames two artifacts, .ostree.tar.bz2 to .ostree.tar.zst and .ostreecommit.tar.xz to .ostreecommit.tar.zst, so anything consuming them by name will break.