### PR TITLE
sota: use KERNEL_CONSOLE for platform defaults

### DIFF
--- a/classes/sota_freedom-u540.bbclass
+++ b/classes/sota_freedom-u540.bbclass
@@ -7,6 +7,6 @@ PREFERRED_PROVIDER_virtual/bootloader_sota ?= "u-boot"
 IMAGE_BOOT_FILES += "uEnv.txt"
 IMAGE_BOOT_FILES:remove = "fitImage"
 
-OSTREE_KERNEL_ARGS:sota ?= "earlycon=sbi console=ttySIF0 ramdisk_size=16384 root=/dev/ram0 rw rootfstype=ext4 rootwait rootdelay=2 ostree_root=/dev/mmcblk0p3"
+OSTREE_KERNEL_ARGS:sota ?= "earlycon=sbi console=${KERNEL_CONSOLE} ramdisk_size=16384 root=/dev/ram0 rw rootfstype=ext4 rootwait rootdelay=2 ostree_root=/dev/mmcblk0p3"
 
 WKS_FILE:sota = "freedom-u540-opensbi-sota.wks"

--- a/classes/sota_intel.bbclass
+++ b/classes/sota_intel.bbclass
@@ -6,7 +6,7 @@ WKS_FILE:sota = "efiimage-sota.wks.in"
 IMAGE_BOOT_FILES:sota = ""
 
 IMAGE_FSTYPES:remove:sota = "live hddimg"
-OSTREE_KERNEL_ARGS ?= "console=ttyS0,115200 ${OSTREE_KERNEL_ARGS_COMMON}"
+OSTREE_KERNEL_ARGS ?= "console=${KERNEL_CONSOLE} ${OSTREE_KERNEL_ARGS_COMMON}"
 
 PREFERRED_RPROVIDER_network-configuration ?= "connman"
 IMAGE_INSTALL:append:sota = " network-configuration "

--- a/classes/sota_qcom.bbclass
+++ b/classes/sota_qcom.bbclass
@@ -9,7 +9,7 @@ IMAGE_TYPEDEP:qcomflash += "ota-ext4 ota-esp"
 
 # Handled by ostree
 UKI_CMDLINE = ""
-OSTREE_KERNEL_ARGS ?= "console=ttyMSM0,115200 ${OSTREE_KERNEL_ARGS_COMMON} ${KERNEL_CMDLINE_EXTRA}"
+OSTREE_KERNEL_ARGS ?= "console=${KERNEL_CONSOLE} ${OSTREE_KERNEL_ARGS_COMMON} ${KERNEL_CMDLINE_EXTRA}"
 
 # No custom esp image required
 QCOM_ESP_IMAGE = ""

--- a/classes/sota_raspberrypi.bbclass
+++ b/classes/sota_raspberrypi.bbclass
@@ -65,7 +65,7 @@ SOTA_DT_OVERLAYS:raspberrypi4 ?= "vc4-fkms-v3d.dtbo uart0.dtbo"
 PREFERRED_PROVIDER_u-boot-default-script ?= "u-boot-otascript"
 
 # Kernel args normally provided by RPi's internal bootloader. Non-updateable
-KERNEL_SERIAL_RPI ?= "${@oe.utils.conditional("ENABLE_UART", "1", "console=ttyS0,115200", "", d)}"
+KERNEL_SERIAL_RPI ?= "${@oe.utils.conditional("ENABLE_UART", "1", "console=${KERNEL_CONSOLE}", "", d)}"
 OSTREE_KERNEL_ARGS_COMMON_RPI ?= "coherent_pool=1M 8250.nr_uarts=1 console=tty1 ${KERNEL_SERIAL_RPI} ${OSTREE_KERNEL_ARGS_COMMON}"
 OSTREE_KERNEL_ARGS:raspberrypi4 ?= "vc_mem.mem_base=0x3ec00000 vc_mem.mem_size=0x40000000 ${OSTREE_KERNEL_ARGS_COMMON_RPI}"
 


### PR DESCRIPTION
The QCOM, Intel, Freedom U540, and Raspberry Pi SOTA classes hardcode platform-specific serial console names when constructing kernel command lines. This can leave OSTree/UKI boot entries inconsistent with machine configuration.

Use the OE-provided KERNEL_CONSOLE variable so these defaults follow the machine-specific SERIAL_CONSOLES setting. Keep existing OSTREE_KERNEL_ARGS overrides and platform-specific kernel command line arguments unchanged.