### PR TITLE
classes/image_types_ota: pull into the OTA sysroot without fsync

### DIFF
--- a/classes/image_types_ota.bbclass
+++ b/classes/image_types_ota.bbclass
@@ -49,7 +49,7 @@ IMAGE_CMD:ota () {
 
 	# Use OSTree hash to avoid any potential race conditions between
 	# multiple builds accessing the same ${OSTREE_REPO}.
-	ostree --repo=${OTA_SYSROOT}/ostree/repo pull-local --remote=${OSTREE_OSNAME} ${OSTREE_REPO} ${ostree_target_hash}
+	ostree --repo=${OTA_SYSROOT}/ostree/repo pull-local --disable-fsync --remote=${OSTREE_OSNAME} ${OSTREE_REPO} ${ostree_target_hash}
 	kargs_list=""
 	for arg in $(printf '%s' "${OSTREE_KERNEL_ARGS}"); do
 		kargs_list="${kargs_list} --karg-append=${arg}"


### PR DESCRIPTION
The pull-local that fills the OTA sysroot writes every object of the deployment into a repository that exists only to be turned into a filesystem image, and fsyncs each one on the way. That durability buys nothing here: the repository lives in WORKDIR, the task is re-run from scratch if it is interrupted, and the artifact that matters is the ota-ext4/btrfs image built from the deployment afterwards. On the network-backed disks of build farms a per-object fsync is a round trip each, so the pull spends much of its time waiting on them.

Pass --disable-fsync. It only affects this one pull: the objects and the resulting image are unchanged, and the sysroot's repository config, which does ship on the device, is left alone (setting core.fsync there would have been the wrong way to get the same effect).